### PR TITLE
fix: clusterctl version

### DIFF
--- a/.bin/b.yaml
+++ b/.bin/b.yaml
@@ -2,3 +2,4 @@ jq:
   version: jq-1.7
 kind:
 mkcert:
+clusterctl:

--- a/pkg/binaries/clusterctl/clusterctl.go
+++ b/pkg/binaries/clusterctl/clusterctl.go
@@ -28,10 +28,13 @@ func Binary(options *binaries.BinaryOptions) *binary.Binary {
 		IsTarGz:    false,
 		VersionLocalF: func(b *binary.Binary) (string, error) {
 			s, err := b.Exec("version", "-o", "short")
-			if err != nil {
+			// https://github.com/kubernetes-sigs/cluster-api/issues/3573
+			// we will ignore the following error
+			// Error: unable to verify clusterctl version: unable to write version state file: mkdir /etc/xdg/cluster-api: permission denied exit status 1
+			if err != nil && (s == "" || s[0] != 'v') {
 				return "", err
 			}
-			return strings.TrimSpace(s), nil
+			return strings.Split(s, "\n")[0], nil
 		},
 	}
 }


### PR DESCRIPTION
This pull request introduces a new cluster management tool and updates error handling in the `clusterctl` binary. The most important changes include adding `clusterctl` to the list of binaries and improving error handling logic to address a specific issue with version verification.

### Additions to binaries:

* [`.bin/b.yaml`](diffhunk://#diff-92e9557e1ba08effd07acb855d09251b3fcfff717de4e4826101419ccb1ce42aR5): Added `clusterctl` as a new binary in the configuration.

### Error handling improvements:

* [`pkg/binaries/clusterctl/clusterctl.go`](diffhunk://#diff-23e6c782401588f0bf7ca966ddb1740135d9f8ad394f38632c507a580acdcdf9L31-R37): Updated the `VersionLocalF` function to handle a specific error case related to permission issues when verifying the `clusterctl` version. The function now ignores the error if the output is empty or does not start with 'v', and it returns the first line of the output instead of trimming whitespace.