### PR TITLE
fix: quiet mode

### DIFF
--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -53,18 +53,21 @@ func NewCmdBinary(options *CmdBinaryOptions) *cobra.Command {
 		Short: "Manage all binaries",
 		Long:  "Ensure that all binaries needed are installed and up to date",
 		PreRunE: func(cmd *cobra.Command, args []string) error {
+			if options.quiet {
+				options.IO.Out = io.Discard
+			}
+
 			path := binary.GetBinaryPath()
 			if path == "" {
 				return cmdutil.UsageErrorf(cmd, "Could not find a suitable path to install binaries")
 			}
+
 			if !options.NoConfig {
 				var err error
 				options.config, err = state.LoadConfig()
 				return err
 			}
-			if options.quiet {
-				options.IO.Out = io.Discard
-			}
+
 			return nil
 		},
 		Example: templates.Examples(`


### PR DESCRIPTION
This pull request refactors the `PreRunE` function in the `NewCmdBinary` command to improve readability and ensure the `quiet` option is handled earlier in the execution flow.

### Refactoring for readability:
* Moved the `quiet` option check to the beginning of the `PreRunE` function to ensure output is discarded immediately when the `quiet` flag is set. This change improves the logical flow and readability of the function. (`[pkg/cli/cli.goR56-R70](diffhunk://#diff-3040c236897f2704958b674ce81c445b6de53f2ff4c204c812ec510de8a76a73R56-R70)`)