### PR TITLE
feat: add kustomize

### DIFF
--- a/.bin/b.yaml
+++ b/.bin/b.yaml
@@ -3,3 +3,4 @@ jq:
 kind:
 mkcert:
 clusterctl:
+kustomize:

--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ Have a look into [pkg/binaries](./pkg/binaries/) for prepackaged binaries.
 - [k9s](https://github.com/derailed/k9s) - Kubernetes CLI to manage your clusters
 - [kind](https://github.com/kubernetes-sigs/kind) - Kubernetes IN Docker
 - [kubectl](https://github.com/kubernetes/kubectl) - Kubernetes CLI to manage your clusters
+- [kustomize](https://github.com/kubernetes-sigs/kustomize) - Kubernetes native configuration management
 - [mkcert](https://github.com/FiloSottile/mkcert) - Create locally-trusted development certificates
 - [tilt](https://github.com/tilt-dev/tilt) - Local Kubernetes development with no stress
 - [yq](https://github.com/mikefarah/yq) - Command-line YAML processor

--- a/cmd/b/main.go
+++ b/cmd/b/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/fentas/b/pkg/binaries/k9s"
 	"github.com/fentas/b/pkg/binaries/kind"
 	"github.com/fentas/b/pkg/binaries/kubectl"
+	"github.com/fentas/b/pkg/binaries/kustomize"
 	"github.com/fentas/b/pkg/binaries/mkcert"
 	"github.com/fentas/b/pkg/binaries/tilt"
 	"github.com/fentas/b/pkg/binaries/yq"
@@ -48,6 +49,7 @@ func main() {
 			k9s.Binary(o),
 			kind.Binary(o),
 			kubectl.Binary(o),
+			kustomize.Binary(o),
 			mkcert.Binary(o),
 			tilt.Binary(o),
 			yq.Binary(o),

--- a/pkg/binaries/kustomize/kustomize.go
+++ b/pkg/binaries/kustomize/kustomize.go
@@ -1,0 +1,44 @@
+package kustomize
+
+import (
+	"context"
+	"fmt"
+	"runtime"
+
+	"github.com/fentas/b/pkg/binaries"
+	"github.com/fentas/b/pkg/binary"
+)
+
+func Binary(options *binaries.BinaryOptions) *binary.Binary {
+	if options == nil {
+		options = &binaries.BinaryOptions{
+			Context: context.Background(),
+		}
+	}
+	return &binary.Binary{
+		Context:    options.Context,
+		Envs:       options.Envs,
+		Tracker:    options.Tracker,
+		Version:    options.Version,
+		Name:       "kustomize",
+		GitHubRepo: "kubernetes-sigs/kustomize",
+		URLF: func(b *binary.Binary) (string, error) {
+			return fmt.Sprintf(
+				"https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%%2F%s/kustomize_%s_%s_%s.tar.gz",
+				b.Version,
+				b.Version,
+				runtime.GOOS,
+				runtime.GOARCH,
+			), nil
+		},
+		VersionF: binary.GithubLatest,
+		IsTarGz:  true,
+		VersionLocalF: func(b *binary.Binary) (string, error) {
+			s, err := b.Exec("version")
+			if err != nil {
+				return "", err
+			}
+			return s, nil
+		},
+	}
+}


### PR DESCRIPTION
This pull request adds support for the `kustomize` binary to the project. The changes include updating configuration files, documentation, and code to integrate `kustomize` as a new binary option.

### Integration of `kustomize` binary:

* **Configuration Updates:**
  - Added `kustomize` to the list of binaries in `.bin/b.yaml`.

* **Documentation Updates:**
  - Updated `README.md` to include a description and link for `kustomize` under the list of prepackaged binaries.

* **Codebase Updates:**
  - Added `kustomize` import in `cmd/b/main.go` and updated the `main` function to include `kustomize.Binary` in the list of binaries. [[1]](diffhunk://#diff-9220de3f3af10d1a2eb38298eefa2c9cc92852596770de03bc85dbbb6d136f9fR19) [[2]](diffhunk://#diff-9220de3f3af10d1a2eb38298eefa2c9cc92852596770de03bc85dbbb6d136f9fR52)
  - Created a new file, `pkg/binaries/kustomize/kustomize.go`, which defines the `Binary` function for `kustomize`. This function specifies how to fetch, configure, and execute the `kustomize` binary, including handling its version and URL.