### PR TITLE
feat: add stern

### DIFF
--- a/.bin/b.yaml
+++ b/.bin/b.yaml
@@ -4,3 +4,4 @@ kind:
 mkcert:
 clusterctl:
 kustomize:
+stern:

--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ Have a look into [pkg/binaries](./pkg/binaries/) for prepackaged binaries.
 - [kubectl](https://github.com/kubernetes/kubectl) - Kubernetes CLI to manage your clusters
 - [kustomize](https://github.com/kubernetes-sigs/kustomize) - Kubernetes native configuration management
 - [mkcert](https://github.com/FiloSottile/mkcert) - Create locally-trusted development certificates
+- [stern](https://github.com/stern/stern) - Simultaneous log tailing for multiple Kubernetes pods and containers
 - [tilt](https://github.com/tilt-dev/tilt) - Local Kubernetes development with no stress
 - [yq](https://github.com/mikefarah/yq) - Command-line YAML processor
 

--- a/cmd/b/main.go
+++ b/cmd/b/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/fentas/b/pkg/binaries/kubectl"
 	"github.com/fentas/b/pkg/binaries/kustomize"
 	"github.com/fentas/b/pkg/binaries/mkcert"
+	"github.com/fentas/b/pkg/binaries/stern"
 	"github.com/fentas/b/pkg/binaries/tilt"
 	"github.com/fentas/b/pkg/binaries/yq"
 	"github.com/spf13/cobra"
@@ -51,6 +52,7 @@ func main() {
 			kubectl.Binary(o),
 			kustomize.Binary(o),
 			mkcert.Binary(o),
+			stern.Binary(o),
 			tilt.Binary(o),
 			yq.Binary(o),
 		},

--- a/pkg/binaries/stern/stern.go
+++ b/pkg/binaries/stern/stern.go
@@ -1,0 +1,47 @@
+package stern
+
+import (
+	"context"
+	"fmt"
+	"runtime"
+	"strings"
+
+	"github.com/fentas/b/pkg/binaries"
+	"github.com/fentas/b/pkg/binary"
+)
+
+func Binary(options *binaries.BinaryOptions) *binary.Binary {
+	if options == nil {
+		options = &binaries.BinaryOptions{
+			Context: context.Background(),
+		}
+	}
+	if options.Envs == nil {
+		options.Envs = map[string]string{}
+	}
+	return &binary.Binary{
+		Context:    options.Context,
+		Envs:       options.Envs,
+		Tracker:    options.Tracker,
+		Version:    options.Version,
+		Name:       "stern",
+		GitHubRepo: "stern/stern",
+		GitHubFileF: func(b *binary.Binary) (string, error) {
+			return fmt.Sprintf("stern_%s_%s_%s.tar.gz",
+				b.Version[1:],
+				runtime.GOOS,
+				runtime.GOARCH,
+			), nil
+		},
+		VersionF: binary.GithubLatest,
+		IsTarGz:  true,
+		VersionLocalF: func(b *binary.Binary) (string, error) {
+			s, err := b.Exec("--version")
+			if err != nil {
+				return "", err
+			}
+			v := strings.Split(strings.SplitN(s, "\n", 2)[0], " ")
+			return "v" + v[len(v)-1], nil
+		},
+	}
+}


### PR DESCRIPTION
This pull request introduces support for the `stern` tool, which enables simultaneous log tailing for multiple Kubernetes pods and containers. The changes include adding the necessary configuration, documentation, and code to integrate `stern` into the project.

### Integration of `stern`:

* **Configuration Updates**:
  - Added `stern` to the `kind:` section in `.bin/b.yaml`.

* **Documentation**:
  - Updated `README.md` to include a description and link for `stern` under the list of prepackaged binaries.

* **Code Changes**:
  - Added the `stern` package import in `cmd/b/main.go` to integrate its functionality.
  - Registered `stern.Binary` in the `func main()` method of `cmd/b/main.go` to enable its usage.
  - Created a new file, `pkg/binaries/stern/stern.go`, to define the `Binary` function for `stern`, including its versioning, GitHub repository details, and local version detection logic.