### PR TITLE
feat: add packer and zip support

### DIFF
--- a/.bin/b.yaml
+++ b/.bin/b.yaml
@@ -6,3 +6,4 @@ clusterctl:
 kustomize:
 stern:
 sops:
+packer:

--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ Have a look into [pkg/binaries](./pkg/binaries/) for prepackaged binaries.
 - [kubectl](https://github.com/kubernetes/kubectl) - Kubernetes CLI to manage your clusters
 - [kustomize](https://github.com/kubernetes-sigs/kustomize) - Kubernetes native configuration management
 - [mkcert](https://github.com/FiloSottile/mkcert) - Create locally-trusted development certificates
+- [packer](https://github.com/hashicorp/packer) - Packer is a tool for creating machine and container images
 - [sops](https://github.com/getsops/sops) - Secure processing of configuration files
 - [stern](https://github.com/stern/stern) - Simultaneous log tailing for multiple Kubernetes pods and containers
 - [tilt](https://github.com/tilt-dev/tilt) - Local Kubernetes development with no stress

--- a/cmd/b/main.go
+++ b/cmd/b/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/fentas/b/pkg/binaries/kubectl"
 	"github.com/fentas/b/pkg/binaries/kustomize"
 	"github.com/fentas/b/pkg/binaries/mkcert"
+	"github.com/fentas/b/pkg/binaries/packer"
 	"github.com/fentas/b/pkg/binaries/sops"
 	"github.com/fentas/b/pkg/binaries/stern"
 	"github.com/fentas/b/pkg/binaries/tilt"
@@ -53,6 +54,7 @@ func main() {
 			kubectl.Binary(o),
 			kustomize.Binary(o),
 			mkcert.Binary(o),
+			packer.Binary(o),
 			sops.Binary(o),
 			stern.Binary(o),
 			tilt.Binary(o),

--- a/pkg/binaries/packer/packer.go
+++ b/pkg/binaries/packer/packer.go
@@ -1,0 +1,48 @@
+package packer
+
+import (
+	"context"
+	"fmt"
+	"runtime"
+	"strings"
+
+	"github.com/fentas/b/pkg/binaries"
+	"github.com/fentas/b/pkg/binary"
+)
+
+func Binary(options *binaries.BinaryOptions) *binary.Binary {
+	if options == nil {
+		options = &binaries.BinaryOptions{
+			Context: context.Background(),
+		}
+	}
+	return &binary.Binary{
+		Context:    options.Context,
+		Envs:       options.Envs,
+		Tracker:    options.Tracker,
+		Version:    options.Version,
+		Name:       "packer",
+		GitHubRepo: "hashicorp/packer",
+		URLF: func(b *binary.Binary) (string, error) {
+			// https://releases.hashicorp.com/packer/1.13.1/packer_1.13.1_linux_amd64.zip
+			return fmt.Sprintf(
+				"https://releases.hashicorp.com/packer/%s/packer_%s_%s_%s.zip",
+				b.Version[1:],
+				b.Version[1:],
+				runtime.GOOS,
+				runtime.GOARCH,
+			), nil
+		},
+		VersionF: binary.GithubLatest,
+		IsZip:    true,
+		VersionLocalF: func(b *binary.Binary) (string, error) {
+			b.Envs["HOME"] = "/tmp"
+			s, err := b.Exec("version")
+			if err != nil {
+				return "", err
+			}
+			v := strings.Split(s, " ")
+			return v[len(v)-1], nil
+		},
+	}
+}

--- a/pkg/binary/binary.go
+++ b/pkg/binary/binary.go
@@ -29,6 +29,7 @@ type Binary struct {
 	Name          string            `json:"name" yaml:"name"`
 	File          string            `json:"-"`
 	IsTarGz       bool              `json:"-"`
+	IsZip         bool              `json:"-"`
 	TarFile       string            `json:"-"`
 	TarFileF      Callback          `json:"-"`
 	Tracker       *progress.Tracker `json:"-"`

--- a/pkg/binary/download.go
+++ b/pkg/binary/download.go
@@ -2,6 +2,8 @@ package binary
 
 import (
 	"archive/tar"
+	"archive/zip"
+	"bytes"
 	"compress/gzip"
 	"fmt"
 	"io"
@@ -63,9 +65,43 @@ func (b *Binary) extractSingleFileFromTarGz(stream io.Reader) error {
 		if err != nil {
 			return err
 		}
-		_, err = io.Copy(file, tarReader)
-		file.Close()
+		defer file.Close()
+		if _, err = io.Copy(file, tarReader); err != nil {
+			return err
+		}
+	}
+
+	return os.Chmod(b.File, 0755)
+}
+
+func (b *Binary) extractSingleFileFromZip(stream io.Reader) error {
+	zipData, err := io.ReadAll(stream)
+	if err != nil {
 		return err
+	}
+
+	zipReader, err := zip.NewReader(bytes.NewReader(zipData), int64(len(zipData)))
+	if err != nil {
+		return err
+	}
+
+	for _, file := range zipReader.File {
+		if file.Name == b.Name {
+			zippedFile, err := file.Open()
+			if err != nil {
+				return err
+			}
+			defer zippedFile.Close()
+
+			bfile, err := os.OpenFile(b.File, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0755)
+			if err != nil {
+				return err
+			}
+			defer bfile.Close()
+			if _, err = io.Copy(bfile, zippedFile); err != nil {
+				return err
+			}
+		}
 	}
 
 	return os.Chmod(b.File, 0755)
@@ -112,6 +148,9 @@ func (b *Binary) downloadBinary() error {
 	}
 	if b.IsTarGz {
 		return b.extractSingleFileFromTarGz(reader)
+	}
+	if b.IsZip {
+		return b.extractSingleFileFromZip(reader)
 	}
 
 	file, err := os.OpenFile(b.File, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0755)


### PR DESCRIPTION
This pull request introduces support for the `packer` binary in the project. The changes include adding the necessary logic to handle `packer` binaries, updating the documentation, and modifying the binary handling system to support `.zip` files. Below is a summary of the most important changes grouped by theme:

### Addition of `packer` Binary Support:
* Added a new `pkg/binaries/packer/packer.go` file, which defines the `Binary` function for handling `packer` binaries, including downloading and extracting them from the HashiCorp repository.
* Updated `cmd/b/main.go` to import the `packer` package and include `packer.Binary(o)` in the list of binaries initialized in the `main` function. [[1]](diffhunk://#diff-9220de3f3af10d1a2eb38298eefa2c9cc92852596770de03bc85dbbb6d136f9fR21) [[2]](diffhunk://#diff-9220de3f3af10d1a2eb38298eefa2c9cc92852596770de03bc85dbbb6d136f9fR57)
* Added `packer` to the list of binaries in the `README.md` file and `.bin/b.yaml` configuration file. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R124) [[2]](diffhunk://#diff-92e9557e1ba08effd07acb855d09251b3fcfff717de4e4826101419ccb1ce42aR9)

### Enhancements to Binary Handling:
* Extended the `Binary` struct in `pkg/binary/binary.go` to include an `IsZip` field, allowing the system to identify `.zip` files.
* Updated `pkg/binary/download.go` to:
  - Add support for extracting single files from `.zip` archives using the `extractSingleFileFromZip` method.
  - Modify the `downloadBinary` method to handle `.zip` files when the `IsZip` field is set.
  - Refactor `extractSingleFileFromTarGz` to use `defer` for closing files, improving code clarity and safety.

These changes ensure seamless integration of `packer` into the existing system and enhance the binary handling capabilities to support `.zip` archives.