### PR TITLE
feat: add kubeseal

### DIFF
--- a/.bin/b.yaml
+++ b/.bin/b.yaml
@@ -7,3 +7,4 @@ kustomize:
 stern:
 sops:
 packer:
+kubeseal:

--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ Have a look into [pkg/binaries](./pkg/binaries/) for prepackaged binaries.
 - [k9s](https://github.com/derailed/k9s) - Kubernetes CLI to manage your clusters
 - [kind](https://github.com/kubernetes-sigs/kind) - Kubernetes IN Docker
 - [kubectl](https://github.com/kubernetes/kubectl) - Kubernetes CLI to manage your clusters
+- [kubeseal](https://github.com/bitnami-labs/sealed-secrets) - A Kubernetes controller and tool for one-way encrypted Secrets
 - [kustomize](https://github.com/kubernetes-sigs/kustomize) - Kubernetes native configuration management
 - [mkcert](https://github.com/FiloSottile/mkcert) - Create locally-trusted development certificates
 - [packer](https://github.com/hashicorp/packer) - Packer is a tool for creating machine and container images

--- a/cmd/b/main.go
+++ b/cmd/b/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/fentas/b/pkg/binaries/k9s"
 	"github.com/fentas/b/pkg/binaries/kind"
 	"github.com/fentas/b/pkg/binaries/kubectl"
+	"github.com/fentas/b/pkg/binaries/kubeseal"
 	"github.com/fentas/b/pkg/binaries/kustomize"
 	"github.com/fentas/b/pkg/binaries/mkcert"
 	"github.com/fentas/b/pkg/binaries/packer"
@@ -52,6 +53,7 @@ func main() {
 			k9s.Binary(o),
 			kind.Binary(o),
 			kubectl.Binary(o),
+			kubeseal.Binary(o),
 			kustomize.Binary(o),
 			mkcert.Binary(o),
 			packer.Binary(o),

--- a/pkg/binaries/kubeseal/kubeseal.go
+++ b/pkg/binaries/kubeseal/kubeseal.go
@@ -1,0 +1,45 @@
+package kubeseal
+
+import (
+	"context"
+	"fmt"
+	"runtime"
+	"strings"
+
+	"github.com/fentas/b/pkg/binaries"
+	"github.com/fentas/b/pkg/binary"
+)
+
+func Binary(options *binaries.BinaryOptions) *binary.Binary {
+	if options == nil {
+		options = &binaries.BinaryOptions{
+			Context: context.Background(),
+		}
+	}
+	return &binary.Binary{
+		Context:    options.Context,
+		Envs:       options.Envs,
+		Tracker:    options.Tracker,
+		Version:    options.Version,
+		Name:       "kubeseal",
+		GitHubRepo: "bitnami-labs/sealed-secrets",
+		GitHubFileF: func(b *binary.Binary) (string, error) {
+			return fmt.Sprintf(
+				"kubeseal-%s-%s-%s.tar.gz",
+				b.Version[1:],
+				runtime.GOOS,
+				runtime.GOARCH,
+			), nil
+		},
+		VersionF: binary.GithubLatest,
+		IsTarGz:  true,
+		VersionLocalF: func(b *binary.Binary) (string, error) {
+			s, err := b.Exec("--version")
+			if err != nil {
+				return "", err
+			}
+			v := strings.Split(s, " ")
+			return "v" + v[len(v)-1], nil
+		},
+	}
+}


### PR DESCRIPTION
This pull request introduces support for the `kubeseal` binary, integrating it into the project alongside existing binaries. The changes include adding a new package for `kubeseal`, updating relevant configuration files, and modifying the main application logic to include `kubeseal` as part of the binary options.

### Additions for `kubeseal` integration:

* **New `kubeseal` package**: Added a new package in `pkg/binaries/kubeseal/kubeseal.go` to define the `kubeseal` binary, including its GitHub repository, versioning logic, and file format handling.

* **Main application updates**:
  * Updated the `import` section in `cmd/b/main.go` to include the `kubeseal` package.
  * Added `kubeseal.Binary(o)` to the list of binaries initialized in the `main` function.

### Documentation updates:

* **`README.md`**: Added an entry for `kubeseal` in the list of prepackaged binaries, with a link to its GitHub repository.

### Configuration updates:

* **`.bin/b.yaml`**: Added `kubeseal` to the configuration file to include it as part of the managed binaries.