### PR TITLE
feat: add hubble binary support with GitHub release integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Have a look at [pkg/binaries](./pkg/binaries/) for prepackaged binaries.
 - [docker-compose](https://github.com/docker/compose) - Define and run multi-container Docker applications
 - [gh](https://github.com/cli/cli) - GitHub CLI wrapper
 - [hcloud](https://github.com/hetznercloud/cli) - Hetzner Cloud CLI wrapper
+- [hubble](https://github.com/cilium/hubble) - Fully distributed networking and security observability platform
 - [jq](https://github.com/jqlang/jq) - Command-line JSON processor
 - [k9s](https://github.com/derailed/k9s) - Kubernetes CLI to manage your clusters
 - [kind](https://github.com/kubernetes-sigs/kind) - Kubernetes IN Docker

--- a/cmd/b/main.go
+++ b/cmd/b/main.go
@@ -13,6 +13,7 @@ import (
 	compose "github.com/fentas/b/pkg/binaries/docker-compose"
 	"github.com/fentas/b/pkg/binaries/gh"
 	"github.com/fentas/b/pkg/binaries/hcloud"
+	"github.com/fentas/b/pkg/binaries/hubble"
 	"github.com/fentas/b/pkg/binaries/jq"
 	"github.com/fentas/b/pkg/binaries/k9s"
 	"github.com/fentas/b/pkg/binaries/kind"
@@ -51,6 +52,7 @@ func main() {
 		curl.Binary(o),
 		gh.Binary(o),
 		hcloud.Binary(o),
+		hubble.Binary(o),
 		jq.Binary(o),
 		k9s.Binary(o),
 		kind.Binary(o),

--- a/pkg/binaries/hubble/hubble.go
+++ b/pkg/binaries/hubble/hubble.go
@@ -1,0 +1,45 @@
+// Package hubble provides a binary for hubble
+package hubble
+
+import (
+	"context"
+	"fmt"
+	"runtime"
+	"strings"
+
+	"github.com/fentas/b/pkg/binaries"
+	"github.com/fentas/b/pkg/binary"
+)
+
+func Binary(options *binaries.BinaryOptions) *binary.Binary {
+	if options == nil {
+		options = &binaries.BinaryOptions{
+			Context: context.Background(),
+		}
+	}
+	return &binary.Binary{
+		Context:    options.Context,
+		Envs:       options.Envs,
+		Tracker:    options.Tracker,
+		Version:    options.Version,
+		Name:       "hubble",
+		GitHubRepo: "cilium/hubble",
+		// https://github.com/cilium/hubble/releases/download/v1.17.5/hubble-linux-amd64.tar.gz
+		GitHubFile: fmt.Sprintf("hubble-%s-%s.tar.gz", runtime.GOOS, runtime.GOARCH),
+		VersionF:   binary.GithubLatest,
+		IsTarGz:    true,
+		// hubble v1.17.5@HEAD-13fb5dc compiled with go1.24.4 on linux/amd64
+		VersionLocalF: func(b *binary.Binary) (string, error) {
+			s, err := b.Exec("version")
+			if err != nil {
+				return "", err
+			}
+			v := strings.Split(s, " ")
+			if len(v) < 2 {
+				return "", fmt.Errorf("version not found")
+			}
+			v = strings.Split(v[1], "@")
+			return v[0], nil
+		},
+	}
+}


### PR DESCRIPTION
This pull request adds support for the `hubble` binary, enabling users to manage and use the Hubble CLI through the project. The changes include updates to the documentation, integration of the new binary into the main command, and the implementation of the binary wrapper.

**New binary integration:**

* Added a new package `pkg/binaries/hubble/hubble.go` that implements the `hubble` binary wrapper, including logic for downloading, extracting, and determining the local version.
* Registered `hubble` in the main command by importing the package and adding it to the list of available binaries in `cmd/b/main.go`. [[1]](diffhunk://#diff-9220de3f3af10d1a2eb38298eefa2c9cc92852596770de03bc85dbbb6d136f9fR16) [[2]](diffhunk://#diff-9220de3f3af10d1a2eb38298eefa2c9cc92852596770de03bc85dbbb6d136f9fR55)

**Documentation update:**

* Updated the `README.md` to include `hubble` in the list of supported binaries.