### PR TITLE
fix: argsh wrong repo

### DIFF
--- a/pkg/binaries/argsh/argsh.go
+++ b/pkg/binaries/argsh/argsh.go
@@ -20,7 +20,7 @@ func Binary(options *binaries.BinaryOptions) *binary.Binary {
 		Tracker:    options.Tracker,
 		Version:    options.Version,
 		Name:       "argsh",
-		GitHubRepo: "fentas/b",
+		GitHubRepo: "arg-sh/argsh",
 		GitHubFile: "argsh",
 		VersionF:   binary.GithubLatest,
 		VersionLocalF: func(b *binary.Binary) (string, error) {


### PR DESCRIPTION
This pull request updates the GitHub repository reference for the `argsh` binary to point to the correct upstream location.

- Repository configuration:
  * In `pkg/binaries/argsh/argsh.go`, the `GitHubRepo` field for the `argsh` binary is changed from `"fentas/b"` to `"arg-sh/argsh"`, ensuring the binary fetches from the correct repository.