### PR TITLE
feat: add binary alias support with renvsubst implementation

### DIFF
--- a/.bin/b.yaml
+++ b/.bin/b.yaml
@@ -1,5 +1,5 @@
-
 binaries:
-  jq:
-    version: jq-1.7
+  envsubst:
+    alias: renvsubst
+  jq: {}
   kubectl: {}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
       "request": "launch",
       "mode": "debug",
       "program": "${workspaceRoot}/cmd/b/main.go",
-      "args": ["-h"]
+      "args": ["v", "envsubst"]
     } 
   ]
 }

--- a/README.md
+++ b/README.md
@@ -79,9 +79,13 @@ binaries:
     version: jq-1.8.1
   kind:
   tilt:
+	# alias to renvsubst
+	envsubst:
+		alias: renvsubst
 ```
 
-This will ensure that `jq`, `kind`, and `tilt` are installed and at the correct version. If you don't specify a version, `b` will install the latest version.
+This will ensure that `jq`, `kind`, `renvsubst` and `tilt` are installed and at the correct version. If you don't specify a version, `b` will install the latest version.
+Note that `renvsubst` is installed as `envsubst`.
 
 &nbsp;
 
@@ -143,6 +147,7 @@ Have a look at [pkg/binaries](./pkg/binaries/) for prepackaged binaries.
 - [kustomize](https://github.com/kubernetes-sigs/kustomize) - Kubernetes native configuration management
 - [mkcert](https://github.com/FiloSottile/mkcert) - Create locally-trusted development certificates
 - [packer](https://github.com/hashicorp/packer) - Packer is a tool for creating machine and container images
+- [renvsubst](https://github.com/containeroo/renvsubst) - envsubst with some extra features written in Rust
 - [sops](https://github.com/getsops/sops) - Secure processing of configuration files
 - [stern](https://github.com/stern/stern) - Simultaneous log tailing for multiple Kubernetes pods and containers
 - [tilt](https://github.com/tilt-dev/tilt) - Local Kubernetes development with no stress

--- a/cmd/b/main.go
+++ b/cmd/b/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/fentas/b/pkg/binaries/kustomize"
 	"github.com/fentas/b/pkg/binaries/mkcert"
 	"github.com/fentas/b/pkg/binaries/packer"
+	"github.com/fentas/b/pkg/binaries/renvsubst"
 	"github.com/fentas/b/pkg/binaries/sops"
 	"github.com/fentas/b/pkg/binaries/stern"
 	"github.com/fentas/b/pkg/binaries/tilt"
@@ -61,6 +62,7 @@ func main() {
 		kustomize.Binary(o),
 		mkcert.Binary(o),
 		packer.Binary(o),
+		renvsubst.Binary(o),
 		sops.Binary(o),
 		stern.Binary(o),
 		tilt.Binary(o),

--- a/pkg/binaries/renvsubst/renvsubst.go
+++ b/pkg/binaries/renvsubst/renvsubst.go
@@ -1,0 +1,54 @@
+package renvsubst
+
+import (
+	"context"
+	"fmt"
+	"runtime"
+
+	"github.com/fentas/b/pkg/binaries"
+	"github.com/fentas/b/pkg/binary"
+)
+
+func sys() string {
+	switch runtime.GOOS {
+	case "darwin":
+		return "x86_64-apple-darwin"
+	case "linux":
+		switch runtime.GOARCH {
+		case "arm":
+			return "armv7-unknown-linux-musleabihf"
+		}
+	}
+	return "x86_64-unknown-linux-musl"
+}
+
+func Binary(options *binaries.BinaryOptions) *binary.Binary {
+	if options == nil {
+		options = &binaries.BinaryOptions{
+			Context: context.Background(),
+		}
+	}
+	return &binary.Binary{
+		Context:    options.Context,
+		Envs:       options.Envs,
+		Tracker:    options.Tracker,
+		Version:    options.Version,
+		Name:       "renvsubst",
+		GitHubRepo: "containeroo/renvsubst",
+		GitHubFileF: func(b *binary.Binary) (string, error) {
+			return fmt.Sprintf("renvsubst-%s-%s.tar.gz",
+				b.Version,
+				sys(),
+			), nil
+		},
+		IsTarGz:  true,
+		VersionF: binary.GithubLatest,
+		VersionLocalF: func(b *binary.Binary) (string, error) {
+			version, err := b.Exec("--version")
+			if err != nil {
+				return "", err
+			}
+			return "v" + version, nil
+		},
+	}
+}

--- a/pkg/binaries/renvsubst/renvsubst.go
+++ b/pkg/binaries/renvsubst/renvsubst.go
@@ -15,11 +15,13 @@ func sys() string {
 		return "x86_64-apple-darwin"
 	case "linux":
 		switch runtime.GOARCH {
+		case "amd64":
+			return "x86_64-unknown-linux-musl"
 		case "arm":
 			return "armv7-unknown-linux-musleabihf"
 		}
 	}
-	return "x86_64-unknown-linux-musl"
+	return ""
 }
 
 func Binary(options *binaries.BinaryOptions) *binary.Binary {
@@ -36,9 +38,13 @@ func Binary(options *binaries.BinaryOptions) *binary.Binary {
 		Name:       "renvsubst",
 		GitHubRepo: "containeroo/renvsubst",
 		GitHubFileF: func(b *binary.Binary) (string, error) {
+			s := sys()
+			if s == "" {
+				return "", fmt.Errorf("unsupported platform: %s/%s", runtime.GOOS, runtime.GOARCH)
+			}
 			return fmt.Sprintf("renvsubst-%s-%s.tar.gz",
 				b.Version,
-				sys(),
+				s,
 			), nil
 		},
 		IsTarGz:  true,

--- a/pkg/binary/binary.go
+++ b/pkg/binary/binary.go
@@ -23,6 +23,7 @@ func (b *Binary) LocalBinary(remote bool) *LocalBinary {
 	}
 	return &LocalBinary{
 		Name:     b.Name,
+		Alias:    b.Alias,
 		File:     file,
 		Version:  version,
 		Latest:   latest,
@@ -35,15 +36,12 @@ func (b *Binary) BinaryPath() string {
 		return b.File
 	}
 
-	// if we find the binary in the PATH, we are done
-	// var err error
-	// if b.File, err = exec.LookPath(b.Name); err == nil {
-	// 	// todo should we block the binary from being updated?
-	// 	return b.File
-	// }
-
+	name := b.Alias
+	if name == "" {
+		name = b.Name
+	}
 	path := path.GetBinaryPath()
-	b.File = filepath.Join(path, b.Name)
+	b.File = filepath.Join(path, name)
 	return b.File
 }
 

--- a/pkg/binary/types.go
+++ b/pkg/binary/types.go
@@ -25,6 +25,7 @@ type Binary struct {
 	Version       string          `json:"-"`
 	VersionF      Callback        `json:"-"`
 	VersionLocalF Callback        `json:"-"`
+	Alias         string          `json:"-"`
 	Name          string          `json:"name" yaml:"name"`
 	File          string          `json:"-"`
 	IsTarGz       bool            `json:"-"`
@@ -45,4 +46,7 @@ type LocalBinary struct {
 	Version  string `json:"version,omitempty"`
 	Latest   string `json:"latest"`
 	Enforced string `json:"enforced,omitempty"`
+	// alias is the name of the binary that this binary is a reference to
+	// yaml config sets this as reference
+	Alias string `json:"alias,omitempty"`
 }

--- a/pkg/cli/shared.go
+++ b/pkg/cli/shared.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"fmt"
 	"io"
 
 	"github.com/fentas/b/pkg/binary"
@@ -122,10 +123,9 @@ func (o *SharedOptions) GetBinariesFromConfig() []*binary.Binary {
 	for _, lb := range o.Config.Binaries {
 		if b, ok := o.resolveBinary(lb); ok {
 			result = append(result, b)
+		} else {
+			fmt.Fprintf(o.IO.ErrOut, "Warning: referenced binary '%s' could not be resolved and will be skipped.\n", lb.Name)
 		}
-		// Note: if resolveBinary returns false, we skip this entry
-		// This happens when a referenced binary is not found
-		// todo error?
 	}
 
 	return result

--- a/pkg/state/types.go
+++ b/pkg/state/types.go
@@ -57,10 +57,22 @@ func (list *BinaryList) MarshalYAML() (interface{}, error) {
 	result := make(map[string]interface{})
 	for _, b := range *list {
 		if b.Name != "" {
+			// Build the binary configuration
+			config := make(map[string]string)
+
+			// Add version if enforced
 			if b.Enforced != "" {
-				result[b.Name] = map[string]string{
-					"version": b.Enforced,
-				}
+				config["version"] = b.Enforced
+			}
+
+			// Add alias if specified
+			if b.Alias != "" {
+				config["alias"] = b.Alias
+			}
+
+			// If we have any configuration, use it; otherwise use empty struct
+			if len(config) > 0 {
+				result[b.Name] = config
 			} else {
 				result[b.Name] = &struct{}{}
 			}

--- a/pkg/state/types.go
+++ b/pkg/state/types.go
@@ -70,7 +70,12 @@ func (list *BinaryList) MarshalYAML() (interface{}, error) {
 				config["alias"] = b.Alias
 			}
 
-			result[b.Name] = config
+			// If we have any configuration, use it; otherwise use empty struct
+			if len(config) > 0 {
+				result[b.Name] = config
+			} else {
+				result[b.Name] = &struct{}{}
+			}
 		}
 	}
 	return result, nil

--- a/pkg/state/types.go
+++ b/pkg/state/types.go
@@ -70,12 +70,7 @@ func (list *BinaryList) MarshalYAML() (interface{}, error) {
 				config["alias"] = b.Alias
 			}
 
-			// If we have any configuration, use it; otherwise use empty struct
-			if len(config) > 0 {
-				result[b.Name] = config
-			} else {
-				result[b.Name] = &struct{}{}
-			}
+			result[b.Name] = config
 		}
 	}
 	return result, nil

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -300,7 +300,7 @@ func TestE2E_Performance(t *testing.T) {
 
 	// Test version command performance
 	start = time.Now()
-	cmd = exec.Command(binaryPath, "version")
+	cmd = exec.Command(binaryPath, "version", "--local")
 	_, err = cmd.CombinedOutput()
 	duration = time.Since(start)
 
@@ -308,7 +308,7 @@ func TestE2E_Performance(t *testing.T) {
 		t.Fatalf("Version command failed: %v", err)
 	}
 
-	if duration > 5*time.Second {
+	if duration > 1*time.Second {
 		t.Errorf("Version command took too long: %v", duration)
 	}
 


### PR DESCRIPTION
This pull request introduces support for binary aliasing, allowing users to install and reference binaries under alternative names (aliases). The primary example is the addition of the `renvsubst` binary, which can be installed and referenced as `envsubst`. The changes update the configuration, installation process, and documentation to support aliases, and add the necessary code to handle alias resolution throughout the binary management workflow.

**Binary aliasing support:**

* Added an `Alias` field to the `Binary` and `LocalBinary` types, and updated the binary resolution logic to handle aliases in configuration and at install time. (`pkg/binary/types.go` [[1]](diffhunk://#diff-dbe71d6065a50e3207d59285f5c94607c54ed42a8463c43039f37363c4aa2959R28) [[2]](diffhunk://#diff-dbe71d6065a50e3207d59285f5c94607c54ed42a8463c43039f37363c4aa2959R49-R51); `pkg/binary/binary.go` [[3]](diffhunk://#diff-00b2199291d16f8fbdfc79abd4e7b71248d6bb942c1a5c7d09f808798b6e9e96R26) [[4]](diffhunk://#diff-00b2199291d16f8fbdfc79abd4e7b71248d6bb942c1a5c7d09f808798b6e9e96L38-R44); `pkg/cli/install.go` [[5]](diffhunk://#diff-ebe54dde8f614cc6f0d132705196614e5b6a48404127318406dac54dd367d937R24) [[6]](diffhunk://#diff-ebe54dde8f614cc6f0d132705196614e5b6a48404127318406dac54dd367d937R54-R56) [[7]](diffhunk://#diff-ebe54dde8f614cc6f0d132705196614e5b6a48404127318406dac54dd367d937L66-R71) [[8]](diffhunk://#diff-ebe54dde8f614cc6f0d132705196614e5b6a48404127318406dac54dd367d937L99-R104) [[9]](diffhunk://#diff-ebe54dde8f614cc6f0d132705196614e5b6a48404127318406dac54dd367d937R171-R177) [[10]](diffhunk://#diff-ebe54dde8f614cc6f0d132705196614e5b6a48404127318406dac54dd367d937R231-R234); `pkg/cli/shared.go` [[11]](diffhunk://#diff-4c44f553ea8f479216482472cf49354360e8ee8deebdb3a167fb7762978afe42R65-R114) [[12]](diffhunk://#diff-4c44f553ea8f479216482472cf49354360e8ee8deebdb3a167fb7762978afe42L79-R128); `pkg/state/types.go` [[13]](diffhunk://#diff-9e3da5c69c0969d315bc1384175c1dc096a797b41502641fdb8183fe55b7bba5R60-R75)

* Updated the YAML config (`.bin/b.yaml`) and documentation (`README.md`) to demonstrate and explain alias usage, particularly for `envsubst` as an alias for `renvsubst`. [[1]](diffhunk://#diff-92e9557e1ba08effd07acb855d09251b3fcfff717de4e4826101419ccb1ce42aL1-R4) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R82-R88) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R150)

**New binary support:**

* Added support for the `renvsubst` binary, including its download and installation logic, and registered it in the main binary list. (`pkg/binaries/renvsubst/renvsubst.go` [[1]](diffhunk://#diff-d9cf6bc8fed5d3a71b1a64543ba6c076b62904733cda4f24d7c3dbe8986de8aaR1-R54); `cmd/b/main.go` [[2]](diffhunk://#diff-9220de3f3af10d1a2eb38298eefa2c9cc92852596770de03bc85dbbb6d136f9fR25) [[3]](diffhunk://#diff-9220de3f3af10d1a2eb38298eefa2c9cc92852596770de03bc85dbbb6d136f9fR65)

**User experience improvements:**

* Improved CLI output to show aliases during installation, and updated help text and flags to document alias usage. (`pkg/cli/install.go` [[1]](diffhunk://#diff-ebe54dde8f614cc6f0d132705196614e5b6a48404127318406dac54dd367d937R54-R56) [[2]](diffhunk://#diff-ebe54dde8f614cc6f0d132705196614e5b6a48404127318406dac54dd367d937L66-R71) [[3]](diffhunk://#diff-ebe54dde8f614cc6f0d132705196614e5b6a48404127318406dac54dd367d937R171-R177)

**Testing and minor fixes:**

* Adjusted E2E test to use a faster timeout and the `--local` flag for the version command. (`test/e2e/main_test.go` [test/e2e/main_test.goL303-R311](diffhunk://#diff-345f4ae23b0645edf99172a04da688e38f03f0e398ca32ec3905d4ecc325cdccL303-R311))
* Minor dependency addition for colored CLI output. (`pkg/cli/install.go` [pkg/cli/install.goR9](diffhunk://#diff-ebe54dde8f614cc6f0d132705196614e5b6a48404127318406dac54dd367d937R9))

These changes enable more flexible binary management by allowing users to install and refer to binaries under custom names, improving compatibility and user experience.