### PR TITLE
feat: add kubelogin binary support for Kubernetes OpenID Connect authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ Have a look at [pkg/binaries](./pkg/binaries/) for prepackaged binaries.
 - [k9s](https://github.com/derailed/k9s) - Kubernetes CLI to manage your clusters
 - [kind](https://github.com/kubernetes-sigs/kind) - Kubernetes IN Docker
 - [kubectl](https://github.com/kubernetes/kubectl) - Kubernetes CLI to manage your clusters
+- [kubelogin - int128](https://github.com/int128/kubelogin) - kubectl plugin for Kubernetes OpenID Connect authentication (kubectl oidc-login)
 - [kubeseal](https://github.com/bitnami-labs/sealed-secrets) - A Kubernetes controller and tool for one-way encrypted Secrets
 - [kustomize](https://github.com/kubernetes-sigs/kustomize) - Kubernetes native configuration management
 - [mkcert](https://github.com/FiloSottile/mkcert) - Create locally-trusted development certificates

--- a/cmd/b/main.go
+++ b/cmd/b/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/fentas/b/pkg/binaries/k9s"
 	"github.com/fentas/b/pkg/binaries/kind"
 	"github.com/fentas/b/pkg/binaries/kubectl"
+	"github.com/fentas/b/pkg/binaries/kubelogin"
 	"github.com/fentas/b/pkg/binaries/kubeseal"
 	"github.com/fentas/b/pkg/binaries/kustomize"
 	"github.com/fentas/b/pkg/binaries/mkcert"
@@ -58,6 +59,7 @@ func main() {
 		k9s.Binary(o),
 		kind.Binary(o),
 		kubectl.Binary(o),
+		kubelogin.Binary(o),
 		kubeseal.Binary(o),
 		kustomize.Binary(o),
 		mkcert.Binary(o),

--- a/pkg/binaries/kubelogin/kubelogin.go
+++ b/pkg/binaries/kubelogin/kubelogin.go
@@ -1,0 +1,46 @@
+package kubelogin
+
+import (
+	"context"
+	"fmt"
+	"runtime"
+	"strings"
+
+	"github.com/fentas/b/pkg/binaries"
+	"github.com/fentas/b/pkg/binary"
+)
+
+func Binary(options *binaries.BinaryOptions) *binary.Binary {
+	if options == nil {
+		options = &binaries.BinaryOptions{
+			Context: context.Background(),
+		}
+	}
+	return &binary.Binary{
+		Context:    options.Context,
+		Envs:       options.Envs,
+		Tracker:    options.Tracker,
+		Version:    options.Version,
+		Name:       "kubelogin",
+		GitHubRepo: "int128/kubelogin",
+		URLF: func(b *binary.Binary) (string, error) {
+			return fmt.Sprintf(
+				"https://github.com/%s/releases/download/%s/kubelogin_%s_%s.zip",
+				b.GitHubRepo,
+				b.Version,
+				runtime.GOOS,
+				runtime.GOARCH,
+			), nil
+		},
+		VersionF: binary.GithubLatest,
+		IsZip:    true,
+		VersionLocalF: func(b *binary.Binary) (string, error) {
+			s, err := b.Exec("--version")
+			if err != nil {
+				return "", err
+			}
+			v := strings.Split(s, " ")
+			return v[len(v)-1], nil
+		},
+	}
+}


### PR DESCRIPTION
This pull request adds support for the `kubelogin` binary (a kubectl plugin for Kubernetes OpenID Connect authentication) to the project. The changes include updating documentation, importing the new binary, registering it in the main command, and implementing the binary logic.

**New binary integration:**

* Added a new `kubelogin` binary implementation in `pkg/binaries/kubelogin/kubelogin.go`, including logic for downloading, extracting version, and handling binary options.
* Registered the `kubelogin` binary in the main application by importing it in `cmd/b/main.go` and adding it to the list of managed binaries. [[1]](diffhunk://#diff-9220de3f3af10d1a2eb38298eefa2c9cc92852596770de03bc85dbbb6d136f9fR21) [[2]](diffhunk://#diff-9220de3f3af10d1a2eb38298eefa2c9cc92852596770de03bc85dbbb6d136f9fR62)

**Documentation update:**

* Updated `README.md` to include `kubelogin` in the list of available binaries, with a link to its GitHub repository and a brief description.