### PR TITLE
feat: add ssh-to-age binary support for converting SSH Ed25519 keys to age keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ Have a look at [pkg/binaries](./pkg/binaries/) for prepackaged binaries.
 - [packer](https://github.com/hashicorp/packer) - Packer is a tool for creating machine and container images
 - [renvsubst](https://github.com/containeroo/renvsubst) - envsubst with some extra features written in Rust
 - [sops](https://github.com/getsops/sops) - Secure processing of configuration files
+- [ssh-to-age](https://github.com/Mic92/ssh-to-age) - Convert SSH Ed25519 keys to age keys
 - [stern](https://github.com/stern/stern) - Simultaneous log tailing for multiple Kubernetes pods and containers
 - [tilt](https://github.com/tilt-dev/tilt) - Local Kubernetes development with no stress
 - [yq](https://github.com/mikefarah/yq) - Command-line YAML processor

--- a/cmd/b/main.go
+++ b/cmd/b/main.go
@@ -25,6 +25,7 @@ import (
 	"github.com/fentas/b/pkg/binaries/packer"
 	"github.com/fentas/b/pkg/binaries/renvsubst"
 	"github.com/fentas/b/pkg/binaries/sops"
+	sshtoage "github.com/fentas/b/pkg/binaries/ssh-to-age"
 	"github.com/fentas/b/pkg/binaries/stern"
 	"github.com/fentas/b/pkg/binaries/tilt"
 	"github.com/fentas/b/pkg/binaries/yq"
@@ -66,6 +67,7 @@ func main() {
 		packer.Binary(o),
 		renvsubst.Binary(o),
 		sops.Binary(o),
+		sshtoage.Binary(o),
 		stern.Binary(o),
 		tilt.Binary(o),
 		yq.Binary(o),

--- a/pkg/binaries/ssh-to-age/ssh-to-age.go
+++ b/pkg/binaries/ssh-to-age/ssh-to-age.go
@@ -1,0 +1,54 @@
+// Package sshtoage binary converts SSH keys to Age keys.
+package sshtoage
+
+import (
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"runtime"
+
+	"github.com/fentas/b/pkg/binaries"
+	"github.com/fentas/b/pkg/binary"
+)
+
+// workaround for version lookup
+// wait for fix https://github.com/Mic92/ssh-to-age/issues/180
+// or get binary sha https://github.com/fentas/b/issues/76
+var versions = map[string]string{
+	"73513156cc8821915ff96b83a9a5780a2993199497c2a3106795de1c54429578": "1.2.0",
+}
+
+func Binary(options *binaries.BinaryOptions) *binary.Binary {
+	if options == nil {
+		options = &binaries.BinaryOptions{
+			Context: context.Background(),
+		}
+	}
+	return &binary.Binary{
+		Context:    options.Context,
+		Envs:       options.Envs,
+		Tracker:    options.Tracker,
+		Version:    options.Version,
+		Name:       "ssh-to-age",
+		GitHubRepo: "Mic92/ssh-to-age",
+		GitHubFile: fmt.Sprintf("ssh-to-age.%s-%s", runtime.GOOS, runtime.GOARCH),
+		VersionF:   binary.GithubLatest,
+		IsTarGz:    false,
+		VersionLocalF: func(b *binary.Binary) (string, error) {
+			s, err := b.Exec("-h")
+			if err != nil {
+				return "", err
+			}
+			// create hash from output
+			hash := sha256.New()
+			if _, err := hash.Write([]byte(s)); err != nil {
+				return "", err
+			}
+			v := fmt.Sprintf("%x", hash.Sum(nil))
+			if _, ok := versions[v]; !ok {
+				return v, nil
+			}
+			return versions[v], nil
+		},
+	}
+}


### PR DESCRIPTION
This pull request adds support for the `ssh-to-age` binary, which allows converting SSH Ed25519 keys to age keys. The changes include updating documentation, importing the new binary, registering it in the main application, and implementing its integration logic.

**New binary integration:**
* Added a new package `pkg/binaries/ssh-to-age` with a `Binary` function to handle downloading, version detection (using a SHA256 hash workaround), and execution of the `ssh-to-age` binary.
* Registered the new `ssh-to-age` binary in the main application by updating the import statements and the binaries list in `cmd/b/main.go`. [[1]](diffhunk://#diff-9220de3f3af10d1a2eb38298eefa2c9cc92852596770de03bc85dbbb6d136f9fR28) [[2]](diffhunk://#diff-9220de3f3af10d1a2eb38298eefa2c9cc92852596770de03bc85dbbb6d136f9fR70)

**Documentation update:**
* Updated `README.md` to include `ssh-to-age` in the list of supported prepackaged binaries.