### PR TITLE
add Docker support with multi-arch builds and GitHub Container Registry integration

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  packages: write
 
 jobs:
   release:
@@ -19,6 +20,16 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Import GPG key
         id: import_gpg

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -57,5 +57,22 @@ archives:
       - LICENSE
       - README.md
 
+dockers:
+  - image_templates:
+      - "ghcr.io/fentas/b:{{ .Tag }}"
+      - "ghcr.io/fentas/b:v{{ .Major }}"
+      - "ghcr.io/fentas/b:v{{ .Major }}.{{ .Minor }}"
+      - "ghcr.io/fentas/b:latest"
+    dockerfile: Dockerfile
+    use: buildx
+    build_flag_templates:
+      - "--pull"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.title={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--label=org.opencontainers.image.source={{.GitURL}}"
+      - "--platform=linux/amd64,linux/arm64"
+
 release:
   draft: false

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,35 @@
+# Build stage
+FROM golang:1.22-alpine AS builder
+
+# Install git for go modules
+RUN apk add --no-cache git
+
+# Set working directory
+WORKDIR /app
+
+# Copy go mod files
+COPY go.mod go.sum ./
+
+# Download dependencies
+RUN go mod download
+
+# Copy source code
+COPY . .
+
+# Build the binary
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build \
+    -ldflags="-w -s" \
+    -o b \
+    ./cmd/b/main.go
+
+# Final stage
+FROM scratch
+
+# Copy the binary from builder stage
+COPY --from=builder /app/b /b
+
+# Copy CA certificates for HTTPS requests
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+
+# Set the entrypoint
+ENTRYPOINT ["/b"]


### PR DESCRIPTION
This pull request introduces Docker support for the project, enabling automated container image builds and publishing as part of the release workflow. Key changes include adding a `Dockerfile`, updating the release workflow to build and push images to GitHub Container Registry, and configuring `goreleaser` to handle Docker image creation and tagging.

**Docker support and image publishing:**

* Added a new `Dockerfile` to build the project binary and create a minimal container image using multi-stage builds.
* Updated `.goreleaser.yaml` to define Docker image templates, tagging schemes, build flags (including multi-platform builds), and container metadata labels for automated image builds and publishing.

**Release workflow enhancements:**

* Modified `.github/workflows/release.yml` to grant `packages: write` permissions for publishing Docker images.
* Added steps in the release workflow to set up Docker Buildx and authenticate with GitHub Container Registry, enabling multi-platform image builds and pushing images as part of the release process.