### PR TITLE
fix: split docker builds into separate amd64/arm64 manifests with multi-arch support

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -58,11 +58,12 @@ archives:
       - README.md
 
 dockers:
-  - image_templates:
-      - "ghcr.io/fentas/b:{{ .Tag }}"
-      - "ghcr.io/fentas/b:v{{ .Major }}"
-      - "ghcr.io/fentas/b:v{{ .Major }}.{{ .Minor }}"
-      - "ghcr.io/fentas/b:latest"
+  - id: amd64
+    image_templates:
+      - "ghcr.io/fentas/b:{{ .Tag }}-amd64"
+      - "ghcr.io/fentas/b:v{{ .Major }}-amd64"
+      - "ghcr.io/fentas/b:v{{ .Major }}.{{ .Minor }}-amd64"
+      - "ghcr.io/fentas/b:latest-amd64"
     dockerfile: Dockerfile
     use: buildx
     build_flag_templates:
@@ -72,7 +73,43 @@ dockers:
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
       - "--label=org.opencontainers.image.version={{.Version}}"
       - "--label=org.opencontainers.image.source={{.GitURL}}"
-      - "--platform=linux/amd64,linux/arm64"
+      - "--platform=linux/amd64"
+    goarch: amd64
+  - id: arm64
+    image_templates:
+      - "ghcr.io/fentas/b:{{ .Tag }}-arm64"
+      - "ghcr.io/fentas/b:v{{ .Major }}-arm64"
+      - "ghcr.io/fentas/b:v{{ .Major }}.{{ .Minor }}-arm64"
+      - "ghcr.io/fentas/b:latest-arm64"
+    dockerfile: Dockerfile
+    use: buildx
+    build_flag_templates:
+      - "--pull"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.title={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--label=org.opencontainers.image.source={{.GitURL}}"
+      - "--platform=linux/arm64"
+    goarch: arm64
+
+docker_manifests:
+  - name_template: "ghcr.io/fentas/b:{{ .Tag }}"
+    image_templates:
+      - "ghcr.io/fentas/b:{{ .Tag }}-amd64"
+      - "ghcr.io/fentas/b:{{ .Tag }}-arm64"
+  - name_template: "ghcr.io/fentas/b:v{{ .Major }}"
+    image_templates:
+      - "ghcr.io/fentas/b:v{{ .Major }}-amd64"
+      - "ghcr.io/fentas/b:v{{ .Major }}-arm64"
+  - name_template: "ghcr.io/fentas/b:v{{ .Major }}.{{ .Minor }}"
+    image_templates:
+      - "ghcr.io/fentas/b:v{{ .Major }}.{{ .Minor }}-amd64"
+      - "ghcr.io/fentas/b:v{{ .Major }}.{{ .Minor }}-arm64"
+  - name_template: "ghcr.io/fentas/b:latest"
+    image_templates:
+      - "ghcr.io/fentas/b:latest-amd64"
+      - "ghcr.io/fentas/b:latest-arm64"
 
 release:
   draft: false


### PR DESCRIPTION
This pull request updates the Docker build and release configuration in `.goreleaser.yaml` to improve multi-architecture support and image publishing. The main changes include splitting Docker builds by architecture and introducing Docker manifest creation for unified multi-arch tags.

**Docker build and publishing improvements:**

* Split Docker builds into separate `amd64` and `arm64` configurations, each with their own `image_templates` and build flags, rather than building both architectures together. [[1]](diffhunk://#diff-7326b55c062b0f46fe9e39aace0a25f4515cf206040fb91a6fd2cae839f5e826L61-R66) [[2]](diffhunk://#diff-7326b55c062b0f46fe9e39aace0a25f4515cf206040fb91a6fd2cae839f5e826L75-R112)
* Added `goarch` field to explicitly specify the target architecture for each Docker build.

**Multi-architecture manifest support:**

* Introduced `docker_manifests` section to create unified multi-architecture tags (e.g., `latest`, versioned tags) that reference both `amd64` and `arm64` images, making it easier for users to pull the correct image for their platform.

https://goreleaser.com/cookbooks/multi-platform-docker-images/#other-things-to-pay-attention-to