### PR TITLE
fix: docker build for goreleaser

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -58,11 +58,12 @@ archives:
       - README.md
 
 dockers:
-  - image_templates:
-      - "ghcr.io/fentas/b:{{ .Tag }}"
-      - "ghcr.io/fentas/b:v{{ .Major }}"
-      - "ghcr.io/fentas/b:v{{ .Major }}.{{ .Minor }}"
-      - "ghcr.io/fentas/b:latest"
+  - id: amd64
+    image_templates:
+      - "ghcr.io/fentas/b:{{ .Tag }}-amd64"
+      - "ghcr.io/fentas/b:v{{ .Major }}-amd64"
+      - "ghcr.io/fentas/b:v{{ .Major }}.{{ .Minor }}-amd64"
+      - "ghcr.io/fentas/b:latest-amd64"
     dockerfile: Dockerfile
     use: buildx
     build_flag_templates:
@@ -72,7 +73,43 @@ dockers:
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
       - "--label=org.opencontainers.image.version={{.Version}}"
       - "--label=org.opencontainers.image.source={{.GitURL}}"
-      - "--platform=linux/amd64,linux/arm64"
+      - "--platform=linux/amd64"
+    goarch: amd64
+  - id: arm64
+    image_templates:
+      - "ghcr.io/fentas/b:{{ .Tag }}-arm64"
+      - "ghcr.io/fentas/b:v{{ .Major }}-arm64"
+      - "ghcr.io/fentas/b:v{{ .Major }}.{{ .Minor }}-arm64"
+      - "ghcr.io/fentas/b:latest-arm64"
+    dockerfile: Dockerfile
+    use: buildx
+    build_flag_templates:
+      - "--pull"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.title={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--label=org.opencontainers.image.source={{.GitURL}}"
+      - "--platform=linux/arm64"
+    goarch: arm64
+
+docker_manifests:
+  - name_template: "ghcr.io/fentas/b:{{ .Tag }}"
+    image_templates:
+      - "ghcr.io/fentas/b:{{ .Tag }}-amd64"
+      - "ghcr.io/fentas/b:{{ .Tag }}-arm64"
+  - name_template: "ghcr.io/fentas/b:v{{ .Major }}"
+    image_templates:
+      - "ghcr.io/fentas/b:v{{ .Major }}-amd64"
+      - "ghcr.io/fentas/b:v{{ .Major }}-arm64"
+  - name_template: "ghcr.io/fentas/b:v{{ .Major }}.{{ .Minor }}"
+    image_templates:
+      - "ghcr.io/fentas/b:v{{ .Major }}.{{ .Minor }}-amd64"
+      - "ghcr.io/fentas/b:v{{ .Major }}.{{ .Minor }}-arm64"
+  - name_template: "ghcr.io/fentas/b:latest"
+    image_templates:
+      - "ghcr.io/fentas/b:latest-amd64"
+      - "ghcr.io/fentas/b:latest-arm64"
 
 release:
   draft: false

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -61,8 +61,6 @@ dockers:
   - id: amd64
     image_templates:
       - "ghcr.io/fentas/b:{{ .Tag }}-amd64"
-      - "ghcr.io/fentas/b:v{{ .Major }}-amd64"
-      - "ghcr.io/fentas/b:v{{ .Major }}.{{ .Minor }}-amd64"
       - "ghcr.io/fentas/b:latest-amd64"
     dockerfile: Dockerfile
     use: buildx
@@ -78,8 +76,6 @@ dockers:
   - id: arm64
     image_templates:
       - "ghcr.io/fentas/b:{{ .Tag }}-arm64"
-      - "ghcr.io/fentas/b:v{{ .Major }}-arm64"
-      - "ghcr.io/fentas/b:v{{ .Major }}.{{ .Minor }}-arm64"
       - "ghcr.io/fentas/b:latest-arm64"
     dockerfile: Dockerfile
     use: buildx
@@ -98,14 +94,6 @@ docker_manifests:
     image_templates:
       - "ghcr.io/fentas/b:{{ .Tag }}-amd64"
       - "ghcr.io/fentas/b:{{ .Tag }}-arm64"
-  - name_template: "ghcr.io/fentas/b:v{{ .Major }}"
-    image_templates:
-      - "ghcr.io/fentas/b:v{{ .Major }}-amd64"
-      - "ghcr.io/fentas/b:v{{ .Major }}-arm64"
-  - name_template: "ghcr.io/fentas/b:v{{ .Major }}.{{ .Minor }}"
-    image_templates:
-      - "ghcr.io/fentas/b:v{{ .Major }}.{{ .Minor }}-amd64"
-      - "ghcr.io/fentas/b:v{{ .Major }}.{{ .Minor }}-arm64"
   - name_template: "ghcr.io/fentas/b:latest"
     image_templates:
       - "ghcr.io/fentas/b:latest-amd64"


### PR DESCRIPTION
This pull request updates the Docker build and release process to improve multi-architecture support and streamline the Dockerfile for use with GoReleaser. The changes separate Docker image builds for `amd64` and `arm64` architectures, introduce Docker manifest creation for multi-arch tags, and simplify the `Dockerfile` to expect pre-built binaries from GoReleaser.

**Multi-architecture Docker image support:**

* The `.goreleaser.yaml` file now defines separate `dockers` entries for `amd64` and `arm64`, each with its own `image_templates` and platform-specific build flags. This replaces the previous single multi-platform build setup. [[1]](diffhunk://#diff-7326b55c062b0f46fe9e39aace0a25f4515cf206040fb91a6fd2cae839f5e826L61-R64) [[2]](diffhunk://#diff-7326b55c062b0f46fe9e39aace0a25f4515cf206040fb91a6fd2cae839f5e826L75-R100)
* Added a `docker_manifests` section to `.goreleaser.yaml` to automatically create multi-architecture image tags (e.g., `ghcr.io/fentas/b:latest` and `ghcr.io/fentas/b:{{ .Tag }}`) that reference both the `amd64` and `arm64` images.

**Dockerfile simplification for GoReleaser:**

* The `Dockerfile` is simplified to use a single `scratch` stage, copying in the pre-built binary (`b`) provided by GoReleaser, instead of building the binary within the Docker build process.
* CA certificates are now copied from the official `alpine:latest` image rather than from a build stage, further minimizing the final image and decoupling it from the build process.