### PR TITLE
feat: add support for custom binary file paths in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,10 +87,19 @@ binaries:
   # alias to renvsubst
   envsubst:
     alias: renvsubst
+  # custom binary with specific file path
+  kubectl:
+    file: ../kc  # absolute or relative to config file
 ```
 
 This will ensure that `jq`, `kind`, `renvsubst` and `tilt` are installed and at the correct version. If you don't specify a version, `b` will install the latest version.
 Note that `renvsubst` is installed as `envsubst`.
+
+You can also specify custom file paths using the `file` field:
+
+- **Relative paths** (like `../kc` or `./bin/tool`) are resolved relative to the config file location
+- **Absolute paths** (like `/usr/local/bin/tool`) are used as-is (be aware of permissions)
+- This allows you to point to existing binaries or specify custom installation locations
 
 &nbsp;
 

--- a/pkg/cli/shared.go
+++ b/pkg/cli/shared.go
@@ -89,6 +89,9 @@ func (o *SharedOptions) resolveBinary(lb *binary.LocalBinary) (*binary.Binary, b
 		if lb.Enforced != "" {
 			b.Version = lb.Enforced
 		}
+		if lb.File != "" {
+			b.File = lb.File
+		}
 	}
 
 	return b, ok

--- a/pkg/state/config.go
+++ b/pkg/state/config.go
@@ -25,6 +25,14 @@ func LoadConfigFromPath(configPath string) (*State, error) {
 		return nil, err
 	}
 
+	// Resolve relative file paths relative to config file location
+	configDir := filepath.Dir(configPath)
+	for _, b := range state.Binaries {
+		if b.File != "" && !filepath.IsAbs(b.File) {
+			b.File = filepath.Join(configDir, b.File)
+		}
+	}
+
 	return &state, nil
 }
 

--- a/pkg/state/types.go
+++ b/pkg/state/types.go
@@ -70,6 +70,11 @@ func (list *BinaryList) MarshalYAML() (interface{}, error) {
 				config["alias"] = b.Alias
 			}
 
+			// Add file if specified
+			if b.File != "" {
+				config["file"] = b.File
+			}
+
 			// If we have any configuration, use it; otherwise use empty struct
 			if len(config) > 0 {
 				result[b.Name] = config


### PR DESCRIPTION
This pull request adds support for specifying custom file paths for binaries in the configuration, allowing users to point to existing binaries or define custom installation locations. The changes ensure that relative paths are resolved based on the config file location and update documentation to explain the new feature.

**Config file and path resolution improvements:**

* Added support for a `file` field in binary configuration, allowing users to specify custom file paths for binaries, with relative paths resolved relative to the config file location (`pkg/state/config.go`, `pkg/cli/shared.go`) [[1]](diffhunk://#diff-7ae457088bab63ed4d15cb172fdcbcad05188895727dd729403f191048a9beb0R28-R35) [[2]](diffhunk://#diff-4c44f553ea8f479216482472cf49354360e8ee8deebdb3a167fb7762978afe42R92-R94).
* Updated binary serialization logic to include the `file` field when present (`pkg/state/types.go`).

**Documentation updates:**

* Expanded the `README.md` to document the new `file` field, including usage examples and path resolution behavior.