### PR TITLE
feat(env): per-key b.pin annotation (#125 phase 2)

### DIFF
--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -304,8 +304,15 @@ func SyncEnv(cfg EnvConfig, projectRoot, cacheRoot string, lockEntry *lock.EnvEn
 		applyPins := func(pending []byte) ([]byte, error) {
 			localFull, readErr := os.ReadFile(destPath)
 			if readErr != nil {
-				// File doesn't exist yet → no local pins to honor.
-				return pending, nil
+				if os.IsNotExist(readErr) {
+					// File doesn't exist yet → no local pins to honor.
+					return pending, nil
+				}
+				// Permission errors or other I/O failures must be
+				// surfaced — silently skipping pin restoration would
+				// hide a real problem and produce surprising sync
+				// output where pinned keys appear to be ignored.
+				return nil, fmt.Errorf("reading local for pin restoration %s: %w", destPath, readErr)
 			}
 			return applyPinsYAML(localFull, pending, m.SourcePath)
 		}

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -295,6 +295,21 @@ func SyncEnv(cfg EnvConfig, projectRoot, cacheRoot string, lockEntry *lock.EnvEn
 			return spliced, nil
 		}
 
+		// applyPins restores any keys in the consumer's local file that
+		// carry a `b.pin: true` annotation, replacing them in the
+		// to-be-written content. This runs after the merge/splice
+		// pipeline so it works uniformly across all strategies and
+		// regardless of whether a select filter is in play. YAML only
+		// for now; non-YAML files pass through unchanged.
+		applyPins := func(pending []byte) ([]byte, error) {
+			localFull, readErr := os.ReadFile(destPath)
+			if readErr != nil {
+				// File doesn't exist yet → no local pins to honor.
+				return pending, nil
+			}
+			return applyPinsYAML(localFull, pending, m.SourcePath)
+		}
+
 		upstreamHash := fmt.Sprintf("%x", sha256.Sum256(content))
 
 		// Determine file mode from upstream
@@ -367,6 +382,10 @@ func SyncEnv(cfg EnvConfig, projectRoot, cacheRoot string, lockEntry *lock.EnvEn
 			if err != nil {
 				return nil, err
 			}
+			target, err = applyPins(target)
+			if err != nil {
+				return nil, fmt.Errorf("applying pins: %w", err)
+			}
 			if !cfg.DryRun {
 				if err := writeFile(destPath, target, fileMode); err != nil {
 					return nil, err
@@ -398,6 +417,10 @@ func SyncEnv(cfg EnvConfig, projectRoot, cacheRoot string, lockEntry *lock.EnvEn
 					if tErr != nil {
 						return nil, tErr
 					}
+					target, tErr = applyPins(target)
+					if tErr != nil {
+						return nil, fmt.Errorf("applying pins: %w", tErr)
+					}
 					status = "replaced (merge failed: " + mergeErr.Error() + ")"
 					if !cfg.DryRun {
 						if err := writeFile(destPath, target, fileMode); err != nil {
@@ -423,6 +446,10 @@ func SyncEnv(cfg EnvConfig, projectRoot, cacheRoot string, lockEntry *lock.EnvEn
 						}
 						spliced = spliceOut
 					}
+					spliced, err = applyPins(spliced)
+					if err != nil {
+						return nil, fmt.Errorf("applying pins: %w", err)
+					}
 					if hasConflict {
 						status = "conflict"
 						conflicts++
@@ -446,6 +473,10 @@ func SyncEnv(cfg EnvConfig, projectRoot, cacheRoot string, lockEntry *lock.EnvEn
 				target, err := computeTargetBytes()
 				if err != nil {
 					return nil, err
+				}
+				target, err = applyPins(target)
+				if err != nil {
+					return nil, fmt.Errorf("applying pins: %w", err)
 				}
 				status = "replaced (local changes overwritten)"
 				if !cfg.DryRun {

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -402,12 +402,21 @@ func SyncEnv(cfg EnvConfig, projectRoot, cacheRoot string, lockEntry *lock.EnvEn
 			if err != nil {
 				return nil, fmt.Errorf("applying pins: %w", err)
 			}
+			finalHash = fmt.Sprintf("%x", sha256.Sum256(target))
+			// Pin restoration intentionally produces a target that
+			// can equal the on-disk file even when the upstream hash
+			// differs (the pinned keys make the file diverge from
+			// upstream). Skip the write when target already matches
+			// on-disk so we don't churn mtime / file watchers on
+			// every sync of a pinned file.
 			if !cfg.DryRun {
-				if err := writeFile(destPath, target, fileMode); err != nil {
-					return nil, err
+				localHash, _ := lock.SHA256File(destPath)
+				if localHash != finalHash {
+					if err := writeFile(destPath, target, fileMode); err != nil {
+						return nil, err
+					}
 				}
 			}
-			finalHash = fmt.Sprintf("%x", sha256.Sum256(target))
 		} else {
 			switch fileStrategy {
 			case StrategyClient:

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -426,6 +426,12 @@ func SyncEnv(cfg EnvConfig, projectRoot, cacheRoot string, lockEntry *lock.EnvEn
 							return nil, fmt.Errorf("updating permissions for %s: %w", destPath, chmodErr)
 						}
 					}
+					// Reflect reality in the plan: nothing
+					// changed on disk, so the row is
+					// unchanged, not replaced. Common when
+					// upstream changes only affect pinned
+					// subtrees.
+					status = "unchanged"
 				}
 			}
 		} else {

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -302,6 +302,15 @@ func SyncEnv(cfg EnvConfig, projectRoot, cacheRoot string, lockEntry *lock.EnvEn
 		// regardless of whether a select filter is in play. YAML only
 		// for now; non-YAML files pass through unchanged.
 		applyPins := func(pending []byte) ([]byte, error) {
+			// Pinning is YAML-only today. Short-circuit non-YAML
+			// destinations BEFORE the os.ReadFile call so the I/O
+			// path can't fail (and surprise users) on JSON / text
+			// files that the helper would always pass through
+			// anyway.
+			ext := strings.ToLower(filepath.Ext(m.SourcePath))
+			if ext != ".yaml" && ext != ".yml" {
+				return pending, nil
+			}
 			localFull, readErr := os.ReadFile(destPath)
 			if readErr != nil {
 				if os.IsNotExist(readErr) {

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -415,6 +415,17 @@ func SyncEnv(cfg EnvConfig, projectRoot, cacheRoot string, lockEntry *lock.EnvEn
 					if err := writeFile(destPath, target, fileMode); err != nil {
 						return nil, err
 					}
+				} else {
+					// Content unchanged but upstream may have
+					// flipped the file mode (e.g. 644→755).
+					// writeFile would normally do this; apply
+					// it explicitly when we skip the write so
+					// permissions stay in sync.
+					if info, statErr := os.Stat(destPath); statErr == nil && info.Mode().Perm() != fileMode {
+						if chmodErr := os.Chmod(destPath, fileMode); chmodErr != nil {
+							return nil, fmt.Errorf("updating permissions for %s: %w", destPath, chmodErr)
+						}
+					}
 				}
 			}
 		} else {

--- a/pkg/env/pin.go
+++ b/pkg/env/pin.go
@@ -1,0 +1,261 @@
+package env
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// PinAnnotation is the local-only field consumers add to a YAML map to
+// opt out of upstream syncing for that specific key. It is namespaced
+// under `b.` to avoid colliding with upstream schemas, and uses a dot
+// rather than a colon for compatibility with YAML 1.2 plain keys.
+//
+//	binaries:
+//	  kubectl:
+//	    version: v1.30.0
+//	    b.pin: true   # ignore upstream for this entry
+//
+// The annotation survives syncs because it lives in the consumer's
+// file and upstream never specifies it. The pin restoration walks the
+// to-be-written content after merge/splice and substitutes the local
+// values back in for any path whose local map carries the annotation.
+const PinAnnotation = "b.pin"
+
+// applyPinsYAML restores pinned keys from `local` into `pending` for
+// YAML files. A "pinned key" is a map node in `local` that has
+// `b.pin: true` set; that map (including the annotation itself) wins
+// over whatever upstream/merge produced for the same path. The path is
+// the sequence of map keys from the document root to the pinned node.
+//
+// The function is a no-op when:
+//   - the file is not YAML (caller filters by extension)
+//   - local has no pinned keys
+//   - pending parses cleanly but the pinned path isn't present
+//
+// Pin scope is intentionally per-key, not per-subtree: if `kubectl`
+// is pinned, the entire `kubectl:` map is preserved verbatim, but
+// pinning `kubectl.version` would only preserve the version field
+// (and the annotation alongside it). The implementation walks the
+// local tree once to collect annotated paths and then walks pending
+// to substitute, leaving everything else untouched.
+func applyPinsYAML(local, pending []byte, filePath string) ([]byte, error) {
+	ext := strings.ToLower(filepath.Ext(filePath))
+	if ext != ".yaml" && ext != ".yml" {
+		return pending, nil
+	}
+	if len(local) == 0 || len(pending) == 0 {
+		return pending, nil
+	}
+
+	var localDoc yaml.Node
+	if err := yaml.Unmarshal(local, &localDoc); err != nil {
+		// Local is unparseable — leave pending alone. The merge path
+		// already errored out for unparseable files; this is just
+		// defensive.
+		return pending, nil
+	}
+	pinned := collectPinnedPaths(&localDoc, nil)
+	if len(pinned) == 0 {
+		return pending, nil
+	}
+
+	var pendingDoc yaml.Node
+	if err := yaml.Unmarshal(pending, &pendingDoc); err != nil {
+		// Pending has conflict markers or is otherwise unparseable.
+		// We can't structurally substitute, so return as-is and let
+		// the conflict-resolution path handle it. The user's pin will
+		// take effect on the next clean sync.
+		return pending, nil
+	}
+
+	for _, p := range pinned {
+		localNode := lookupPath(&localDoc, p.path)
+		if localNode == nil {
+			continue
+		}
+		if !setPath(&pendingDoc, p.path, localNode) {
+			// Path didn't exist in pending — pinned key was deleted
+			// upstream and consumer wants to keep it. Add it back.
+			addPath(&pendingDoc, p.path, localNode)
+		}
+	}
+
+	var buf strings.Builder
+	enc := yaml.NewEncoder(&yamlStringWriter{&buf})
+	enc.SetIndent(2)
+	if err := enc.Encode(&pendingDoc); err != nil {
+		return nil, fmt.Errorf("re-emit pinned doc: %w", err)
+	}
+	_ = enc.Close()
+	return []byte(buf.String()), nil
+}
+
+type yamlStringWriter struct{ b *strings.Builder }
+
+func (w *yamlStringWriter) Write(p []byte) (int, error) {
+	w.b.Write(p)
+	return len(p), nil
+}
+
+// pinnedPath records one annotated key in the local document.
+type pinnedPath struct {
+	path []string
+}
+
+// collectPinnedPaths walks a yaml.Node tree and returns the dotted
+// path of every map that contains a `b.pin: true` annotation. The
+// returned path is the sequence of map keys leading TO the pinned
+// map (not including b.pin itself).
+func collectPinnedPaths(n *yaml.Node, prefix []string) []pinnedPath {
+	if n == nil {
+		return nil
+	}
+	if n.Kind == yaml.DocumentNode && len(n.Content) > 0 {
+		return collectPinnedPaths(n.Content[0], prefix)
+	}
+	if n.Kind != yaml.MappingNode {
+		return nil
+	}
+	var out []pinnedPath
+	// First pass: is THIS map pinned?
+	for i := 0; i+1 < len(n.Content); i += 2 {
+		k := n.Content[i]
+		v := n.Content[i+1]
+		if k.Value == PinAnnotation && isTrueScalar(v) && len(prefix) > 0 {
+			cp := make([]string, len(prefix))
+			copy(cp, prefix)
+			out = append(out, pinnedPath{path: cp})
+			break
+		}
+	}
+	// Recurse into children regardless, so nested pins are also found.
+	for i := 0; i+1 < len(n.Content); i += 2 {
+		k := n.Content[i]
+		v := n.Content[i+1]
+		if v.Kind == yaml.MappingNode {
+			out = append(out, collectPinnedPaths(v, append(prefix, k.Value))...)
+		}
+	}
+	return out
+}
+
+func isTrueScalar(n *yaml.Node) bool {
+	if n == nil || n.Kind != yaml.ScalarNode {
+		return false
+	}
+	v := strings.ToLower(strings.TrimSpace(n.Value))
+	return v == "true" || v == "yes" || v == "on"
+}
+
+// lookupPath descends a yaml document tree along the given key path
+// and returns the value node, or nil if any segment is missing.
+func lookupPath(doc *yaml.Node, path []string) *yaml.Node {
+	n := doc
+	if n.Kind == yaml.DocumentNode && len(n.Content) > 0 {
+		n = n.Content[0]
+	}
+	for _, seg := range path {
+		if n == nil || n.Kind != yaml.MappingNode {
+			return nil
+		}
+		var found *yaml.Node
+		for i := 0; i+1 < len(n.Content); i += 2 {
+			if n.Content[i].Value == seg {
+				found = n.Content[i+1]
+				break
+			}
+		}
+		if found == nil {
+			return nil
+		}
+		n = found
+	}
+	return n
+}
+
+// setPath replaces the value at the given path with `replacement` in
+// the document tree. Returns true on success, false if the path didn't
+// exist (caller can fall through to addPath).
+func setPath(doc *yaml.Node, path []string, replacement *yaml.Node) bool {
+	if len(path) == 0 {
+		return false
+	}
+	n := doc
+	if n.Kind == yaml.DocumentNode && len(n.Content) > 0 {
+		n = n.Content[0]
+	}
+	for i, seg := range path {
+		if n == nil || n.Kind != yaml.MappingNode {
+			return false
+		}
+		for j := 0; j+1 < len(n.Content); j += 2 {
+			if n.Content[j].Value == seg {
+				if i == len(path)-1 {
+					n.Content[j+1] = replacement
+					return true
+				}
+				n = n.Content[j+1]
+				goto next
+			}
+		}
+		return false
+	next:
+	}
+	return false
+}
+
+// addPath inserts a value at the given path, creating intermediate
+// maps as needed. Used when the pinned key was deleted upstream and
+// the consumer's annotation says "keep it anyway".
+func addPath(doc *yaml.Node, path []string, value *yaml.Node) {
+	if len(path) == 0 {
+		return
+	}
+	n := doc
+	if n.Kind == yaml.DocumentNode {
+		if len(n.Content) == 0 {
+			n.Content = append(n.Content, &yaml.Node{Kind: yaml.MappingNode, Tag: "!!map"})
+		}
+		n = n.Content[0]
+	}
+	for i, seg := range path {
+		if n.Kind != yaml.MappingNode {
+			return
+		}
+		var found *yaml.Node
+		for j := 0; j+1 < len(n.Content); j += 2 {
+			if n.Content[j].Value == seg {
+				found = n.Content[j+1]
+				break
+			}
+		}
+		if i == len(path)-1 {
+			if found != nil {
+				// already exists; should have been handled by setPath,
+				// but be defensive and replace.
+				for j := 0; j+1 < len(n.Content); j += 2 {
+					if n.Content[j].Value == seg {
+						n.Content[j+1] = value
+						return
+					}
+				}
+			}
+			n.Content = append(n.Content,
+				&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: seg},
+				value)
+			return
+		}
+		if found == nil {
+			child := &yaml.Node{Kind: yaml.MappingNode, Tag: "!!map"}
+			n.Content = append(n.Content,
+				&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: seg},
+				child)
+			n = child
+			continue
+		}
+		n = found
+	}
+}

--- a/pkg/env/pin.go
+++ b/pkg/env/pin.go
@@ -50,6 +50,11 @@ const PinAnnotation = "b.pin"
 // exist in pending (because upstream deleted them) are reinserted
 // from local.
 //
+// A `b.pin: true` at the document root is the "pin the whole
+// document" instruction — equivalent to setting `strategy: client`
+// for that one file. applyPinsYAML returns local verbatim when it
+// sees a root pin, so the splice's bytes are preserved exactly.
+//
 // Formatting caveat: when pin restoration actually substitutes a
 // subtree, the file is round-tripped through the yaml.v3 encoder,
 // so comments and whitespace on the affected file are NOT
@@ -88,6 +93,16 @@ func applyPinsYAML(local, pending []byte, filePath string) ([]byte, error) {
 	pinned := collectPinnedPaths(&localDoc, nil)
 	if len(pinned) == 0 {
 		return pending, nil
+	}
+	// A root-level pin (empty path) is the "pin the whole
+	// document" instruction: keep local verbatim and ignore
+	// upstream entirely. Equivalent to strategy: client at the
+	// per-file level. Detect first so we don't waste a parse on
+	// pending.
+	for _, p := range pinned {
+		if len(p.path) == 0 {
+			return local, nil
+		}
 	}
 
 	// Pending may be empty (a brand-new file) or header-only (no
@@ -232,11 +247,15 @@ func collectPinnedPaths(n *yaml.Node, prefix []string) []pinnedPath {
 		return nil
 	}
 	var out []pinnedPath
-	// First pass: is THIS map pinned?
+	// First pass: is THIS map pinned? An empty prefix means we're
+	// looking at the document root — that's a "pin the whole
+	// document" instruction, recorded as a pinnedPath with an empty
+	// path. applyPinsYAML special-cases that and returns local
+	// verbatim.
 	for i := 0; i+1 < len(n.Content); i += 2 {
 		k := n.Content[i]
 		v := n.Content[i+1]
-		if k.Value == PinAnnotation && isTrueScalar(v) && len(prefix) > 0 {
+		if k.Value == PinAnnotation && isTrueScalar(v) {
 			cp := make([]string, len(prefix))
 			copy(cp, prefix)
 			out = append(out, pinnedPath{path: cp})

--- a/pkg/env/pin.go
+++ b/pkg/env/pin.go
@@ -35,12 +35,14 @@ const PinAnnotation = "b.pin"
 //   - local has no pinned keys
 //   - pending parses cleanly but the pinned path isn't present
 //
-// Pin scope is intentionally per-key, not per-subtree: if `kubectl`
-// is pinned, the entire `kubectl:` map is preserved verbatim, but
-// pinning `kubectl.version` would only preserve the version field
-// (and the annotation alongside it). The implementation walks the
-// local tree once to collect annotated paths and then walks pending
-// to substitute, leaving everything else untouched.
+// Pin scope is per-map-node: if `kubectl` is pinned, the entire
+// `kubectl:` map is preserved verbatim. Deeper pins only apply when
+// the path is itself a nested map node that can carry the
+// `b.pin: true` annotation; scalar fields like a typical
+// `kubectl.version` value cannot be pinned directly because there is
+// nowhere to attach the annotation. The implementation walks the
+// local tree once to collect annotated map paths and then walks
+// pending to substitute, leaving everything else untouched.
 func applyPinsYAML(local, pending []byte, filePath string) ([]byte, error) {
 	ext := strings.ToLower(filepath.Ext(filePath))
 	if ext != ".yaml" && ext != ".yml" {
@@ -89,7 +91,9 @@ func applyPinsYAML(local, pending []byte, filePath string) ([]byte, error) {
 	if err := enc.Encode(&pendingDoc); err != nil {
 		return nil, fmt.Errorf("re-emit pinned doc: %w", err)
 	}
-	_ = enc.Close()
+	if err := enc.Close(); err != nil {
+		return nil, fmt.Errorf("finalize pinned doc: %w", err)
+	}
 	return []byte(buf.String()), nil
 }
 

--- a/pkg/env/pin.go
+++ b/pkg/env/pin.go
@@ -188,11 +188,21 @@ func yamlNodesStructurallyEqual(a, b *yaml.Node) bool {
 		if err := e.Encode(n); err != nil {
 			return nil
 		}
-		_ = e.Close()
+		// Close can flush buffered errors. If it fails the
+		// encoded bytes may be incomplete, in which case the
+		// equality check would compare a partial encoding and
+		// produce a wrong answer (either skipping a needed
+		// substitution or doing an unnecessary one). Return
+		// nil so the outer comparison falls through to the
+		// "not equal" branch and the substitution path runs
+		// — that's the safer side.
+		if err := e.Close(); err != nil {
+			return nil
+		}
 		return []byte(buf.String())
 	}
 	ab, bb := enc(a), enc(b)
-	return ab != nil && bytes.Equal(ab, bb)
+	return ab != nil && bb != nil && bytes.Equal(ab, bb)
 }
 
 type yamlStringWriter struct{ b *strings.Builder }

--- a/pkg/env/pin.go
+++ b/pkg/env/pin.go
@@ -34,7 +34,12 @@ const PinAnnotation = "b.pin"
 // The function is a no-op when:
 //   - the file is not YAML (caller filters by extension)
 //   - local has no pinned keys
-//   - pending parses cleanly but the pinned path isn't present
+//   - pending is unparseable (e.g. has conflict markers) — handled
+//     on a future clean sync
+//
+// Pinned paths that exist in `local` but NOT in `pending` are
+// reinserted via addPath, so a key the consumer pinned that
+// upstream then deleted is preserved.
 //
 // Pin scope is per-map-node: if `kubectl` is pinned, the entire
 // `kubectl:` map is preserved verbatim. Deeper pins only apply when

--- a/pkg/env/pin.go
+++ b/pkg/env/pin.go
@@ -42,13 +42,15 @@ const PinAnnotation = "b.pin"
 // `kubectl.version` value cannot be pinned directly because there is
 // nowhere to attach the annotation. The implementation walks the
 // local tree once to collect annotated map paths and then walks
-// pending to substitute, leaving everything else untouched.
+// pending to substitute. Pinned paths that don't exist in pending
+// (because upstream deleted them) are reinserted from local.
 func applyPinsYAML(local, pending []byte, filePath string) ([]byte, error) {
 	ext := strings.ToLower(filepath.Ext(filePath))
 	if ext != ".yaml" && ext != ".yml" {
 		return pending, nil
 	}
-	if len(local) == 0 || len(pending) == 0 {
+	if len(local) == 0 {
+		// No local file → nothing pinned to honor.
 		return pending, nil
 	}
 
@@ -64,13 +66,43 @@ func applyPinsYAML(local, pending []byte, filePath string) ([]byte, error) {
 		return pending, nil
 	}
 
+	// Pending may be empty (a brand-new file) or header-only (no
+	// document content). Synthesize a minimal mapping document so
+	// addPath has somewhere to attach pinned keys. The yaml.v3
+	// encoder will emit it cleanly.
 	var pendingDoc yaml.Node
-	if err := yaml.Unmarshal(pending, &pendingDoc); err != nil {
-		// Pending has conflict markers or is otherwise unparseable.
-		// We can't structurally substitute, so return as-is and let
-		// the conflict-resolution path handle it. The user's pin will
-		// take effect on the next clean sync.
-		return pending, nil
+	if len(pending) == 0 {
+		pendingDoc = yaml.Node{
+			Kind:    yaml.DocumentNode,
+			Content: []*yaml.Node{{Kind: yaml.MappingNode, Tag: "!!map"}},
+		}
+	} else {
+		if err := yaml.Unmarshal(pending, &pendingDoc); err != nil {
+			// Pending has conflict markers or is otherwise unparseable.
+			// We can't structurally substitute, so return as-is and let
+			// the conflict-resolution path handle it. The user's pin
+			// will take effect on the next clean sync.
+			return pending, nil
+		}
+		// Header-only or empty document: yaml.v3 may leave the
+		// document as the zero value (Kind == 0) rather than a
+		// proper DocumentNode. Coerce both shapes into a synthetic
+		// mapping document so setPath / addPath have somewhere to
+		// walk into.
+		if pendingDoc.Kind == 0 || (pendingDoc.Kind == yaml.DocumentNode && len(pendingDoc.Content) == 0) {
+			pendingDoc = yaml.Node{
+				Kind:    yaml.DocumentNode,
+				Content: []*yaml.Node{{Kind: yaml.MappingNode, Tag: "!!map"}},
+			}
+		}
+		if pendingDoc.Kind != yaml.DocumentNode {
+			return pending, nil
+		}
+		if pendingDoc.Content[0].Kind != yaml.MappingNode {
+			// Pending root is not a mapping (sequence, scalar) —
+			// pinning doesn't apply, leave it alone.
+			return pending, nil
+		}
 	}
 
 	for _, p := range pinned {

--- a/pkg/env/pin.go
+++ b/pkg/env/pin.go
@@ -1,6 +1,7 @@
 package env
 
 import (
+	"bytes"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -51,6 +52,16 @@ func applyPinsYAML(local, pending []byte, filePath string) ([]byte, error) {
 	}
 	if len(local) == 0 {
 		// No local file → nothing pinned to honor.
+		return pending, nil
+	}
+	// Cheap pre-check: a file with no `b.pin` substring anywhere
+	// can't possibly carry a pin annotation, and we'd spend the
+	// yaml.Unmarshal cost on every sync of every YAML file just to
+	// learn that. Substring matches can produce false positives
+	// (e.g. a key literally named "b.pin" elsewhere), but those
+	// just trigger the slow path — the structural collectPinnedPaths
+	// is the source of truth.
+	if !bytes.Contains(local, []byte(PinAnnotation)) {
 		return pending, nil
 	}
 

--- a/pkg/env/pin.go
+++ b/pkg/env/pin.go
@@ -42,14 +42,22 @@ const PinAnnotation = "b.pin"
 // upstream then deleted is preserved.
 //
 // Pin scope is per-map-node: if `kubectl` is pinned, the entire
-// `kubectl:` map is preserved verbatim. Deeper pins only apply when
-// the path is itself a nested map node that can carry the
-// `b.pin: true` annotation; scalar fields like a typical
-// `kubectl.version` value cannot be pinned directly because there is
-// nowhere to attach the annotation. The implementation walks the
-// local tree once to collect annotated map paths and then walks
-// pending to substitute. Pinned paths that don't exist in pending
-// (because upstream deleted them) are reinserted from local.
+// `kubectl:` map is replaced with the local version. Deeper pins
+// only apply when the path is itself a nested map node that can
+// carry the `b.pin: true` annotation; scalar fields like a typical
+// `kubectl.version` value cannot be pinned directly because there
+// is nowhere to attach the annotation. Pinned paths that don't
+// exist in pending (because upstream deleted them) are reinserted
+// from local.
+//
+// Formatting caveat: when pin restoration actually substitutes a
+// subtree, the file is round-tripped through the yaml.v3 encoder,
+// so comments and whitespace on the affected file are NOT
+// preserved (yaml.v3 has no format-preserving emitter for this
+// kind of edit-in-place). When every pinned subtree already
+// matches what the splice produced, applyPinsYAML returns the
+// splice's bytes verbatim — so the common no-drift case keeps
+// splice's byte-preservation guarantees.
 func applyPinsYAML(local, pending []byte, filePath string) ([]byte, error) {
 	ext := strings.ToLower(filepath.Ext(filePath))
 	if ext != ".yaml" && ext != ".yml" {
@@ -121,9 +129,22 @@ func applyPinsYAML(local, pending []byte, filePath string) ([]byte, error) {
 		}
 	}
 
+	changed := false
 	for _, p := range pinned {
 		localNode := lookupPath(&localDoc, p.path)
 		if localNode == nil {
+			continue
+		}
+		// Skip when pending already has the exact same subtree at
+		// this path. This is the common case for syncs where the
+		// pinned keys haven't drifted yet, and skipping the
+		// substitution lets the function fall through to the
+		// "return pending unchanged" branch — which preserves
+		// every byte that the splice carefully laid out, instead
+		// of round-tripping the whole document through yaml.v3
+		// and dropping comments / whitespace.
+		if pendingNode := lookupPath(&pendingDoc, p.path); pendingNode != nil &&
+			yamlNodesStructurallyEqual(pendingNode, localNode) {
 			continue
 		}
 		if !setPath(&pendingDoc, p.path, localNode) {
@@ -131,6 +152,15 @@ func applyPinsYAML(local, pending []byte, filePath string) ([]byte, error) {
 			// upstream and consumer wants to keep it. Add it back.
 			addPath(&pendingDoc, p.path, localNode)
 		}
+		changed = true
+	}
+	if !changed {
+		// No pinned subtree needed substitution: every pin already
+		// matches what the splice produced. Return the splice's
+		// bytes verbatim instead of round-tripping through the
+		// yaml.v3 encoder, which would otherwise reformat the
+		// whole file.
+		return pending, nil
 	}
 
 	var buf strings.Builder
@@ -143,6 +173,26 @@ func applyPinsYAML(local, pending []byte, filePath string) ([]byte, error) {
 		return nil, fmt.Errorf("finalize pinned doc: %w", err)
 	}
 	return []byte(buf.String()), nil
+}
+
+// yamlNodesStructurallyEqual reports whether two yaml.Node trees
+// encode to the same canonical bytes. We use the encoder rather than
+// comparing fields directly so style/comment differences (which the
+// pin restoration explicitly doesn't care about) don't trip the
+// equality check.
+func yamlNodesStructurallyEqual(a, b *yaml.Node) bool {
+	enc := func(n *yaml.Node) []byte {
+		var buf strings.Builder
+		e := yaml.NewEncoder(&yamlStringWriter{&buf})
+		e.SetIndent(2)
+		if err := e.Encode(n); err != nil {
+			return nil
+		}
+		_ = e.Close()
+		return []byte(buf.String())
+	}
+	ab, bb := enc(a), enc(b)
+	return ab != nil && bytes.Equal(ab, bb)
 }
 
 type yamlStringWriter struct{ b *strings.Builder }

--- a/pkg/env/pin_test.go
+++ b/pkg/env/pin_test.go
@@ -185,6 +185,33 @@ func TestApplyPinsYAML_NestedPinAtArbitraryDepth(t *testing.T) {
 	}
 }
 
+// TestApplyPinsYAML_TruthyValueVariants covers the documented set of
+// truthy values for b.pin: true / yes / on, plus mixed-case variants.
+// Without this coverage a future "tighten the parser" change could
+// silently drop yes/on support without breaking any test.
+func TestApplyPinsYAML_TruthyValueVariants(t *testing.T) {
+	pending := []byte(`binaries:
+  kubectl:
+    version: v1.31.0
+`)
+	for _, val := range []string{"true", "yes", "on", "True", "YES", "On"} {
+		t.Run(val, func(t *testing.T) {
+			local := []byte(`binaries:
+  kubectl:
+    version: v1.30.0
+    b.pin: ` + val + `
+`)
+			out, err := applyPinsYAML(local, pending, "b.yaml")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !strings.Contains(string(out), "v1.30.0") {
+				t.Errorf("b.pin: %s should pin, got:\n%s", val, out)
+			}
+		})
+	}
+}
+
 // TestApplyPinsYAML_PinFalseIsNotAPin documents that only true-ish
 // values (true/yes/on) trigger the pin. `false` is treated as "no
 // pin set" so the upstream value can flow through.

--- a/pkg/env/pin_test.go
+++ b/pkg/env/pin_test.go
@@ -1,0 +1,183 @@
+package env
+
+import (
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// TestApplyPinsYAML_PinnedTopLevelKeySurvives the pinned key in local
+// must overwrite the value the merge produced.
+func TestApplyPinsYAML_PinnedTopLevelKeySurvives(t *testing.T) {
+	local := []byte(`binaries:
+  kubectl:
+    version: v1.30.0
+    b.pin: true
+  kustomize:
+    version: v5.0.0
+`)
+	pending := []byte(`binaries:
+  kubectl:
+    version: v1.31.0
+  kustomize:
+    version: v5.5.0
+`)
+	out, err := applyPinsYAML(local, pending, "b.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(out)
+	if !strings.Contains(s, "v1.30.0") {
+		t.Errorf("pinned kubectl version lost: %s", s)
+	}
+	if strings.Contains(s, "v1.31.0") {
+		t.Errorf("pinned kubectl wasn't restored: %s", s)
+	}
+	// kustomize is not pinned → upstream value wins.
+	if !strings.Contains(s, "v5.5.0") {
+		t.Errorf("kustomize update lost: %s", s)
+	}
+	// pin annotation must remain so the next sync still honors it.
+	if !strings.Contains(s, "b.pin") {
+		t.Errorf("pin annotation stripped: %s", s)
+	}
+}
+
+// TestApplyPinsYAML_NoPinsIsNoOp returns pending unchanged when local
+// has no annotations. The function must short-circuit cheaply, not
+// re-emit YAML and risk reformatting.
+func TestApplyPinsYAML_NoPinsIsNoOp(t *testing.T) {
+	local := []byte("binaries:\n  kubectl: {}\n")
+	pending := []byte("binaries:\n  kubectl:\n    version: v2\n")
+	out, err := applyPinsYAML(local, pending, "b.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(out) != string(pending) {
+		t.Errorf("expected pass-through, got:\n%s", out)
+	}
+}
+
+// TestApplyPinsYAML_NonYAMLPasses non-YAML files don't get pin handling.
+func TestApplyPinsYAML_NonYAMLPasses(t *testing.T) {
+	out, err := applyPinsYAML([]byte("local"), []byte("pending"), "config.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(out) != "pending" {
+		t.Errorf("expected pass-through for JSON, got: %s", out)
+	}
+}
+
+// TestApplyPinsYAML_PinAddsBackDeletedKey: pinned key was deleted
+// upstream → consumer's annotation says "keep it anyway", so the
+// pinned entry is reinserted in the pending document.
+func TestApplyPinsYAML_PinAddsBackDeletedKey(t *testing.T) {
+	local := []byte(`binaries:
+  helm:
+    version: v3.14.0
+    b.pin: true
+  kubectl:
+    version: v1.30.0
+`)
+	pending := []byte(`binaries:
+  kubectl:
+    version: v1.31.0
+`)
+	out, err := applyPinsYAML(local, pending, "b.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(out)
+	if !strings.Contains(s, "helm") {
+		t.Errorf("deleted-but-pinned helm should be re-added: %s", s)
+	}
+	if !strings.Contains(s, "v3.14.0") {
+		t.Errorf("helm version lost: %s", s)
+	}
+}
+
+// TestApplyPinsYAML_NestedPinAtArbitraryDepth: a pin deep in the tree
+// is honored just like a top-level one.
+func TestApplyPinsYAML_NestedPinAtArbitraryDepth(t *testing.T) {
+	local := []byte(`envs:
+  github.com/x/y:
+    files:
+      a.yaml:
+        dest: a.yaml
+        b.pin: true
+        custom: keep-me
+`)
+	pending := []byte(`envs:
+  github.com/x/y:
+    files:
+      a.yaml:
+        dest: changed.yaml
+`)
+	out, err := applyPinsYAML(local, pending, "b.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(out)
+	if strings.Contains(s, "changed.yaml") {
+		t.Errorf("upstream value should not have replaced pinned key: %s", s)
+	}
+	if !strings.Contains(s, "keep-me") {
+		t.Errorf("pinned subtree fields lost: %s", s)
+	}
+}
+
+// TestApplyPinsYAML_PinFalseIsNotApin documents that only true-ish
+// values (true/yes/on) trigger the pin. `false` is treated as "no
+// pin set" so the upstream value can flow through.
+func TestApplyPinsYAML_PinFalseIsNotApin(t *testing.T) {
+	local := []byte(`binaries:
+  kubectl:
+    version: v1.30.0
+    b.pin: false
+`)
+	pending := []byte(`binaries:
+  kubectl:
+    version: v1.31.0
+`)
+	out, err := applyPinsYAML(local, pending, "b.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(out), "v1.31.0") {
+		t.Errorf("upstream value should have flowed through with b.pin: false, got:\n%s", out)
+	}
+}
+
+// TestCollectPinnedPaths exercises the path discovery directly so
+// regressions show up before the splice does.
+func TestCollectPinnedPaths(t *testing.T) {
+	local := []byte(`a:
+  b:
+    b.pin: true
+    x: 1
+  c:
+    x: 2
+d:
+  b.pin: true
+`)
+	var doc yaml.Node
+	if err := yaml.Unmarshal(local, &doc); err != nil {
+		t.Fatal(err)
+	}
+	pins := collectPinnedPaths(&doc, nil)
+	if len(pins) != 2 {
+		t.Fatalf("want 2 pins, got %d: %+v", len(pins), pins)
+	}
+	wantPaths := map[string]bool{
+		"a.b": true,
+		"d":   true,
+	}
+	for _, p := range pins {
+		key := strings.Join(p.path, ".")
+		if !wantPaths[key] {
+			t.Errorf("unexpected pin path: %s", key)
+		}
+	}
+}

--- a/pkg/env/pin_test.go
+++ b/pkg/env/pin_test.go
@@ -98,6 +98,63 @@ func TestApplyPinsYAML_PinAddsBackDeletedKey(t *testing.T) {
 	}
 }
 
+// TestApplyPinsYAML_EmptyPendingPreservesPinned covers the case where
+// pending is brand-new / empty (e.g. first sync of a file the
+// consumer was previously maintaining manually). The pinned keys
+// from local must be carried over instead of dropped.
+func TestApplyPinsYAML_EmptyPendingPreservesPinned(t *testing.T) {
+	local := []byte(`binaries:
+  helm:
+    version: v3.14.0
+    b.pin: true
+`)
+	out, err := applyPinsYAML(local, nil, "b.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(out)
+	if !strings.Contains(s, "helm") || !strings.Contains(s, "v3.14.0") {
+		t.Errorf("pinned key not carried over to empty pending: %s", s)
+	}
+}
+
+// TestApplyPinsYAML_HeaderOnlyPending covers a pending document that
+// has only header comments (no actual content). yaml.v3 leaves
+// Document.Content empty in that case; the helper must synthesize a
+// mapping root instead of crashing.
+func TestApplyPinsYAML_HeaderOnlyPending(t *testing.T) {
+	local := []byte(`a:
+  b.pin: true
+  v: 1
+`)
+	pending := []byte("# only a comment\n")
+	out, err := applyPinsYAML(local, pending, "b.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(out), "v: 1") {
+		t.Errorf("pinned subtree dropped: %s", out)
+	}
+}
+
+// TestApplyPinsYAML_NonMappingPendingPassesThrough: if pending has a
+// sequence or scalar root, pinning doesn't apply and we leave it
+// alone.
+func TestApplyPinsYAML_NonMappingPendingPassesThrough(t *testing.T) {
+	local := []byte(`a:
+  b.pin: true
+  v: 1
+`)
+	pending := []byte("- one\n- two\n")
+	out, err := applyPinsYAML(local, pending, "b.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(out) != string(pending) {
+		t.Errorf("non-mapping pending should pass through: got %q", out)
+	}
+}
+
 // TestApplyPinsYAML_NestedPinAtArbitraryDepth: a pin deep in the tree
 // is honored just like a top-level one.
 func TestApplyPinsYAML_NestedPinAtArbitraryDepth(t *testing.T) {

--- a/pkg/env/pin_test.go
+++ b/pkg/env/pin_test.go
@@ -212,6 +212,31 @@ func TestApplyPinsYAML_TruthyValueVariants(t *testing.T) {
 	}
 }
 
+// TestApplyPinsYAML_RootPinPreservesLocalVerbatim covers the
+// document-root pin case: `b.pin: true` at the top level pins the
+// entire file, and the function must return local bytes verbatim
+// (equivalent to strategy: client for that one file).
+func TestApplyPinsYAML_RootPinPreservesLocalVerbatim(t *testing.T) {
+	local := []byte(`b.pin: true
+binaries:
+  kubectl:
+    version: v1.30.0
+  helm:
+    version: v3.14.0
+`)
+	pending := []byte(`binaries:
+  kubectl:
+    version: v1.99.0
+`)
+	out, err := applyPinsYAML(local, pending, "b.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(out) != string(local) {
+		t.Errorf("root pin should return local verbatim, got:\n%s", out)
+	}
+}
+
 // TestApplyPinsYAML_PinFalseIsNotAPin documents that only true-ish
 // values (true/yes/on) trigger the pin. `false` is treated as "no
 // pin set" so the upstream value can flow through.

--- a/pkg/env/pin_test.go
+++ b/pkg/env/pin_test.go
@@ -128,10 +128,10 @@ func TestApplyPinsYAML_NestedPinAtArbitraryDepth(t *testing.T) {
 	}
 }
 
-// TestApplyPinsYAML_PinFalseIsNotApin documents that only true-ish
+// TestApplyPinsYAML_PinFalseIsNotAPin documents that only true-ish
 // values (true/yes/on) trigger the pin. `false` is treated as "no
 // pin set" so the upstream value can flow through.
-func TestApplyPinsYAML_PinFalseIsNotApin(t *testing.T) {
+func TestApplyPinsYAML_PinFalseIsNotAPin(t *testing.T) {
 	local := []byte(`binaries:
   kubectl:
     version: v1.30.0


### PR DESCRIPTION
## Summary
- Adds the \`b.pin: true\` annotation from #125 phase 2
- Pinned map nodes in the consumer's local YAML are preserved verbatim across syncs
- Works regardless of strategy (\`replace\` / \`merge\` / \`client\`) or safety tier
- Pinned-but-deleted-upstream keys are restored

## Why
Phase 2 of issue #125: scalpel-level overrides for individual keys without flipping the whole file to \`strategy: client\`. Lets a consumer pin \`kubectl: v1.30\` for a specific reason while still letting \`kustomize\` flow through normal sync.

## Behavior
\`\`\`yaml
binaries:
  kubectl:
    version: v1.30.0
    b.pin: true       # ignore upstream for this entry
  kustomize:
    version: v5.0.0   # no annotation → updated from upstream
\`\`\`

- Truthy: \`true\`, \`yes\`, \`on\` (case-insensitive). \`b.pin: false\` is a no-op so users can toggle it.
- Annotation itself is preserved across syncs.
- Pinned key absent in upstream → re-added from local.
- YAML only; JSON pinning is a follow-up.

## Test plan
- [x] \`go test ./pkg/env/... -run Pin\`
- [x] full \`go test ./...\`
- [x] \`golangci-lint run ./pkg/env/...\`

Refs #125

🤖 Generated with [Claude Code](https://claude.com/claude-code)