### PR TITLE
feat(env): orphan-file delete plumbing (#125 phase 3)

### DIFF
--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -818,8 +818,6 @@ func syncMessage(files []lock.LockFile, deleted []lock.LockFile, conflicts int) 
 			deletes++
 		}
 	}
-	_ = deleteNoops // currently surfaced via the plan, not the message
-
 	parts := []string{}
 	total := len(files)
 	if total == 0 && deletes == 0 && deleteSkips == 0 && deleteNoops == 0 {
@@ -851,6 +849,12 @@ func syncMessage(files []lock.LockFile, deleted []lock.LockFile, conflicts int) 
 	}
 	if deleteSkips > 0 {
 		parts = append(parts, fmt.Sprintf("%d delete(s) skipped", deleteSkips))
+	}
+	if deleteNoops > 0 {
+		parts = append(parts, fmt.Sprintf("%d delete(s) already gone", deleteNoops))
+	}
+	if len(parts) == 0 {
+		return "no changes"
 	}
 	return strings.Join(parts, ", ")
 }

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -496,12 +496,17 @@ func SyncEnv(cfg EnvConfig, projectRoot, cacheRoot string, lockEntry *lock.EnvEn
 	// next to the existing strict/prompt/auto safety logic.
 	var deletedFiles []lock.LockFile
 	if lockEntry != nil {
-		matchedSet := make(map[string]bool, len(matched))
+		// Match by (source path, dest path) so a file that's still
+		// in upstream but whose dest changed (e.g. user edited
+		// glob config or `dest:`) still surfaces the old dest as
+		// an orphan that needs cleaning up.
+		type fileKey struct{ src, dest string }
+		matchedSet := make(map[fileKey]bool, len(matched))
 		for _, m := range matched {
-			matchedSet[m.SourcePath] = true
+			matchedSet[fileKey{src: m.SourcePath, dest: m.DestPath}] = true
 		}
 		for _, prev := range lockEntry.Files {
-			if matchedSet[prev.Path] {
+			if matchedSet[fileKey{src: prev.Path, dest: prev.Dest}] {
 				continue
 			}
 			absDest := prev.Dest
@@ -801,25 +806,29 @@ func syncMessage(files []lock.LockFile, deleted []lock.LockFile, conflicts int) 
 			// conflicts are reported separately via the conflicts argument
 		}
 	}
-	deletes, deleteSkips := 0, 0
+	deletes, deleteSkips, deleteNoops := 0, 0, 0
 	for _, f := range deleted {
 		status := strings.TrimSuffix(f.Status, " (dry-run)")
-		if strings.HasPrefix(status, "delete-skipped") {
+		switch {
+		case strings.HasPrefix(status, "delete-skipped"):
 			deleteSkips++
-		} else {
+		case strings.HasPrefix(status, "delete-noop"):
+			deleteNoops++
+		default:
 			deletes++
 		}
 	}
+	_ = deleteNoops // currently surfaced via the plan, not the message
 
 	parts := []string{}
 	total := len(files)
-	if total == 0 && deletes == 0 && deleteSkips == 0 {
+	if total == 0 && deletes == 0 && deleteSkips == 0 && deleteNoops == 0 {
 		return "0 file(s) synced"
 	}
-	if replaced == total && deletes == 0 && deleteSkips == 0 {
+	if replaced == total && deletes == 0 && deleteSkips == 0 && deleteNoops == 0 {
 		return fmt.Sprintf("%d file(s) synced", total)
 	}
-	if unchanged == total && deletes == 0 && deleteSkips == 0 {
+	if unchanged == total && deletes == 0 && deleteSkips == 0 && deleteNoops == 0 {
 		return fmt.Sprintf("%d file(s) unchanged", total)
 	}
 	if replaced > 0 {

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -54,9 +54,15 @@ type SyncResult struct {
 	Commit         string
 	PreviousCommit string
 	Files          []lock.LockFile
-	Skipped        bool   // true if already up-to-date
-	Message        string // human-readable status
-	Conflicts      int    // number of files with merge conflicts
+	// Deleted lists files that were in the previous lock but are no
+	// longer in upstream's manifest. They are kept separate from
+	// Files so the lock writer never persists them, while still
+	// being available to PlanFromResult so they show up as `delete`
+	// rows in the plan. See #125 phase 3.
+	Deleted   []lock.LockFile
+	Skipped   bool   // true if already up-to-date
+	Message   string // human-readable status
+	Conflicts int    // number of files with merge conflicts
 }
 
 // SyncEnv syncs environment files from an upstream git repo.
@@ -477,6 +483,62 @@ func SyncEnv(cfg EnvConfig, projectRoot, cacheRoot string, lockEntry *lock.EnvEn
 		})
 	}
 
+	// Detect orphans: files that were in the previous lock but no
+	// longer match upstream's current manifest. They are emitted as
+	// rows in result.Deleted so the planner shows them as `delete`
+	// actions and the safety gate can refuse the plan in strict mode.
+	//
+	// Phase 3 of #125: this PR adds the *plumbing* — detection and
+	// plan rendering. Wiring the actual on-disk removal through the
+	// gateApply layer is a deliberate follow-up: the existing flow
+	// runs SyncEnv once for dry-run and once for apply, and the
+	// "should I really delete?" decision belongs in the CLI layer
+	// next to the existing strict/prompt/auto safety logic.
+	var deletedFiles []lock.LockFile
+	if lockEntry != nil {
+		matchedSet := make(map[string]bool, len(matched))
+		for _, m := range matched {
+			matchedSet[m.SourcePath] = true
+		}
+		for _, prev := range lockEntry.Files {
+			if matchedSet[prev.Path] {
+				continue
+			}
+			absDest := prev.Dest
+			if !filepath.IsAbs(absDest) {
+				absDest = filepath.Join(projectRoot, absDest)
+			}
+			absDest = filepath.Clean(absDest)
+			// Path-traversal check on the previous-lock dest, just
+			// like the in-loop branch does for current files. A
+			// stale or malicious lock entry must not let SyncEnv
+			// surface paths outside the project root.
+			if err := ValidatePathUnderRoot(projectRoot, absDest); err != nil {
+				return nil, fmt.Errorf("path traversal rejected for orphan %s: %w", prev.Dest, err)
+			}
+			deleteStatus := "deleted"
+			if cfg.DryRun {
+				deleteStatus = "deleted (dry-run)"
+			}
+			// If the consumer has modified the file relative to the
+			// recorded lock SHA, surface that as `delete-skipped`
+			// instead of `deleted` so the plan reflects the safer
+			// outcome. The CLI's gateApply layer can use this to
+			// drop the row from "actually delete" candidates while
+			// still warning the user.
+			if localHash, _ := lock.SHA256File(absDest); localHash != "" && localHash != prev.SHA256 {
+				deleteStatus = "delete-skipped (local modified)"
+			}
+			deletedFiles = append(deletedFiles, lock.LockFile{
+				Path:   prev.Path,
+				Dest:   prev.Dest,
+				SHA256: "",
+				Mode:   prev.Mode,
+				Status: deleteStatus,
+			})
+		}
+	}
+
 	// Run post-sync hook (skip in dry-run mode)
 	if cfg.OnPostSync != "" && !cfg.DryRun {
 		if err := runHook(cfg.OnPostSync, projectRoot, hookStdout(cfg), hookStderr(cfg)); err != nil {
@@ -491,6 +553,7 @@ func SyncEnv(cfg EnvConfig, projectRoot, cacheRoot string, lockEntry *lock.EnvEn
 		Commit:         commit,
 		PreviousCommit: previousCommit,
 		Files:          lockFiles,
+		Deleted:        deletedFiles,
 		Message:        syncMessage(lockFiles, conflicts),
 		Conflicts:      conflicts,
 	}, nil

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -520,18 +520,23 @@ func SyncEnv(cfg EnvConfig, projectRoot, cacheRoot string, lockEntry *lock.EnvEn
 			if cfg.DryRun {
 				deleteStatus = "deleted (dry-run)"
 			}
-			// If the consumer has modified the file relative to the
-			// recorded lock SHA, surface that as `delete-skipped`
-			// instead of `deleted` so the plan reflects the safer
-			// outcome. Distinguish a missing file (already gone, no
-			// problem) from a real read failure (permission denied,
-			// transient I/O) — the latter must NOT silently fall
-			// back to a destructive `deleted` row.
+			// Three branches:
+			//   - file already missing on disk → emit
+			//     "delete-noop (already gone)" so the planner
+			//     renders it as a non-destructive keep row;
+			//     the consumer doesn't need to do anything.
+			//   - file unreadable (permissions, transient I/O)
+			//     → emit "delete-skipped (unreadable)" so a real
+			//     read failure never silently maps to a
+			//     destructive deleted row.
+			//   - file present but modified relative to the
+			//     previous lock → emit "delete-skipped (local
+			//     modified)" so the consumer's edits are kept.
+			//   - otherwise → keep the default "deleted" status.
 			localHash, hashErr := lock.SHA256File(absDest)
 			switch {
 			case hashErr != nil && os.IsNotExist(hashErr):
-				// File already missing on disk → keep the default
-				// deleted status; nothing destructive to do.
+				deleteStatus = "delete-noop (already gone)"
 			case hashErr != nil:
 				deleteStatus = "delete-skipped (unreadable)"
 			case localHash != "" && localHash != prev.SHA256:

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -523,10 +523,18 @@ func SyncEnv(cfg EnvConfig, projectRoot, cacheRoot string, lockEntry *lock.EnvEn
 			// If the consumer has modified the file relative to the
 			// recorded lock SHA, surface that as `delete-skipped`
 			// instead of `deleted` so the plan reflects the safer
-			// outcome. The CLI's gateApply layer can use this to
-			// drop the row from "actually delete" candidates while
-			// still warning the user.
-			if localHash, _ := lock.SHA256File(absDest); localHash != "" && localHash != prev.SHA256 {
+			// outcome. Distinguish a missing file (already gone, no
+			// problem) from a real read failure (permission denied,
+			// transient I/O) — the latter must NOT silently fall
+			// back to a destructive `deleted` row.
+			localHash, hashErr := lock.SHA256File(absDest)
+			switch {
+			case hashErr != nil && os.IsNotExist(hashErr):
+				// File already missing on disk → keep the default
+				// deleted status; nothing destructive to do.
+			case hashErr != nil:
+				deleteStatus = "delete-skipped (unreadable)"
+			case localHash != "" && localHash != prev.SHA256:
 				deleteStatus = "delete-skipped (local modified)"
 			}
 			deletedFiles = append(deletedFiles, lock.LockFile{
@@ -554,7 +562,7 @@ func SyncEnv(cfg EnvConfig, projectRoot, cacheRoot string, lockEntry *lock.EnvEn
 		PreviousCommit: previousCommit,
 		Files:          lockFiles,
 		Deleted:        deletedFiles,
-		Message:        syncMessage(lockFiles, conflicts),
+		Message:        syncMessage(lockFiles, deletedFiles, conflicts),
 		Conflicts:      conflicts,
 	}, nil
 }
@@ -765,7 +773,12 @@ func fileModeToString(mode os.FileMode) string {
 }
 
 // syncMessage builds a human-readable sync message from file results.
-func syncMessage(files []lock.LockFile, conflicts int) string {
+// Orphan delete rows are passed in separately because they live on
+// SyncResult.Deleted (not Files) so the lock writer never persists
+// them — but the user-facing message must still account for them or
+// "upstream removed all files" syncs would misleadingly read as
+// "0 files synced".
+func syncMessage(files []lock.LockFile, deleted []lock.LockFile, conflicts int) string {
 	replaced, kept, merged, unchanged := 0, 0, 0, 0
 	for _, f := range files {
 		// Strip dry-run suffix for counting
@@ -783,13 +796,25 @@ func syncMessage(files []lock.LockFile, conflicts int) string {
 			// conflicts are reported separately via the conflicts argument
 		}
 	}
+	deletes, deleteSkips := 0, 0
+	for _, f := range deleted {
+		status := strings.TrimSuffix(f.Status, " (dry-run)")
+		if strings.HasPrefix(status, "delete-skipped") {
+			deleteSkips++
+		} else {
+			deletes++
+		}
+	}
 
 	parts := []string{}
 	total := len(files)
-	if replaced == total {
+	if total == 0 && deletes == 0 && deleteSkips == 0 {
+		return "0 file(s) synced"
+	}
+	if replaced == total && deletes == 0 && deleteSkips == 0 {
 		return fmt.Sprintf("%d file(s) synced", total)
 	}
-	if unchanged == total {
+	if unchanged == total && deletes == 0 && deleteSkips == 0 {
 		return fmt.Sprintf("%d file(s) unchanged", total)
 	}
 	if replaced > 0 {
@@ -806,6 +831,12 @@ func syncMessage(files []lock.LockFile, conflicts int) string {
 	}
 	if unchanged > 0 {
 		parts = append(parts, fmt.Sprintf("%d unchanged", unchanged))
+	}
+	if deletes > 0 {
+		parts = append(parts, fmt.Sprintf("%d deleted", deletes))
+	}
+	if deleteSkips > 0 {
+		parts = append(parts, fmt.Sprintf("%d delete(s) skipped", deleteSkips))
 	}
 	return strings.Join(parts, ", ")
 }

--- a/pkg/env/env_extra_test.go
+++ b/pkg/env/env_extra_test.go
@@ -51,7 +51,7 @@ func TestFindLockFile_EmptyFiles(t *testing.T) {
 }
 
 func TestSyncMessage_EmptyFiles(t *testing.T) {
-	got := syncMessage(nil, 0)
+	got := syncMessage(nil, nil, 0)
 	if got != "0 file(s) synced" {
 		t.Errorf("syncMessage(nil) = %q", got)
 	}
@@ -62,7 +62,7 @@ func TestSyncMessage_AllMerged(t *testing.T) {
 		{Status: "merged"},
 		{Status: "merged"},
 	}
-	got := syncMessage(files, 0)
+	got := syncMessage(files, nil, 0)
 	if got != "2 merged" {
 		t.Errorf("syncMessage() = %q, want %q", got, "2 merged")
 	}
@@ -73,7 +73,7 @@ func TestSyncMessage_ReplacedWithLocalChanges(t *testing.T) {
 		{Status: "replaced (local changes overwritten)"},
 		{Status: "replaced"},
 	}
-	got := syncMessage(files, 0)
+	got := syncMessage(files, nil, 0)
 	if got != "2 file(s) synced" {
 		t.Errorf("syncMessage() = %q, want %q", got, "2 file(s) synced")
 	}
@@ -131,7 +131,7 @@ func TestSyncMessage_MixedStatuses(t *testing.T) {
 		{Status: "kept"},
 		{Status: "merged"},
 	}
-	got := syncMessage(files, 0)
+	got := syncMessage(files, nil, 0)
 	if got == "" {
 		t.Error("expected non-empty message")
 	}
@@ -142,7 +142,7 @@ func TestSyncMessage_WithConflicts(t *testing.T) {
 		{Status: "replaced"},
 		{Status: "conflict"},
 	}
-	got := syncMessage(files, 1)
+	got := syncMessage(files, nil, 1)
 	if got == "" {
 		t.Error("expected non-empty message")
 	}
@@ -153,7 +153,7 @@ func TestSyncMessage_AllKept(t *testing.T) {
 		{Status: "kept"},
 		{Status: "kept"},
 	}
-	got := syncMessage(files, 0)
+	got := syncMessage(files, nil, 0)
 	if got != "2 kept" {
 		t.Errorf("syncMessage() = %q, want %q", got, "2 kept")
 	}

--- a/pkg/env/env_test.go
+++ b/pkg/env/env_test.go
@@ -80,7 +80,7 @@ func TestSyncMessage(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := syncMessage(tt.files, tt.conflicts)
+			got := syncMessage(tt.files, nil, tt.conflicts)
 			if got != tt.want {
 				t.Errorf("syncMessage() = %q, want %q", got, tt.want)
 			}

--- a/pkg/env/features_test.go
+++ b/pkg/env/features_test.go
@@ -21,7 +21,7 @@ func TestSyncMessage_WithUnchanged(t *testing.T) {
 		{Status: "unchanged"},
 		{Status: "unchanged"},
 	}
-	got := syncMessage(files, 0)
+	got := syncMessage(files, nil, 0)
 	if got == "" {
 		t.Error("expected non-empty message")
 	}
@@ -36,7 +36,7 @@ func TestSyncMessage_AllUnchanged(t *testing.T) {
 		{Status: "unchanged"},
 		{Status: "unchanged"},
 	}
-	got := syncMessage(files, 0)
+	got := syncMessage(files, nil, 0)
 	if got != "2 file(s) unchanged" {
 		t.Errorf("syncMessage() = %q, want %q", got, "2 file(s) unchanged")
 	}
@@ -189,7 +189,7 @@ func TestSyncMessage_DryRunSuffix(t *testing.T) {
 		{Status: "replaced (dry-run)"},
 		{Status: "replaced (dry-run)"},
 	}
-	got := syncMessage(files, 0)
+	got := syncMessage(files, nil, 0)
 	if got != "2 file(s) synced" {
 		t.Errorf("syncMessage() with dry-run = %q, want %q", got, "2 file(s) synced")
 	}
@@ -199,7 +199,7 @@ func TestSyncMessage_UnchangedDryRun(t *testing.T) {
 	files := []lock.LockFile{
 		{Status: "unchanged (dry-run)"},
 	}
-	got := syncMessage(files, 0)
+	got := syncMessage(files, nil, 0)
 	// Should strip dry-run and count as unchanged
 	if got != "1 file(s) unchanged" {
 		t.Errorf("syncMessage() = %q, want %q", got, "1 file(s) unchanged")

--- a/pkg/env/plan.go
+++ b/pkg/env/plan.go
@@ -217,10 +217,11 @@ func planRowFromLockFile(f lock.LockFile, prevPaths map[string]bool) PlanRow {
 //	'!' overwrite path/to/file
 //	'⊕' merge     path/to/file
 //	'✗' conflict  path/to/file
+//	'-' delete    path/to/file
 //
 // A summary line is printed at the end with non-zero counts only:
 //
-//	→ 12 add, 3 update, 1 conflict
+//	→ 12 add, 3 update, 1 conflict, 1 delete
 func RenderPlanText(w io.Writer, p *Plan) {
 	if p == nil || len(p.Rows) == 0 {
 		fmt.Fprintln(w, "  (no files)")

--- a/pkg/env/plan.go
+++ b/pkg/env/plan.go
@@ -22,13 +22,14 @@ const (
 	PlanOverwrite PlanAction = "overwrite" // local changes will be replaced by upstream
 	PlanMerge     PlanAction = "merge"     // 3-way merge applied (or would be), no conflict
 	PlanConflict  PlanAction = "conflict"  // 3-way merge produced conflict markers; needs manual resolution
+	PlanDelete    PlanAction = "delete"    // file existed in previous lock but no longer in upstream; will be removed
 )
 
 // IsDestructive reports whether an action would lose user-owned content.
 // Strict safety mode refuses to apply a plan whose actions are destructive.
 func (a PlanAction) IsDestructive() bool {
 	switch a {
-	case PlanOverwrite, PlanConflict:
+	case PlanOverwrite, PlanConflict, PlanDelete:
 		return true
 	default:
 		return false
@@ -124,6 +125,13 @@ func PlanFromResult(result *SyncResult, prev *lock.EnvEntry) *Plan {
 	for _, f := range result.Files {
 		p.Rows = append(p.Rows, planRowFromLockFile(f, prevPaths))
 	}
+	// Orphan files (in previous lock but no longer in upstream) live
+	// on result.Deleted so the lock writer never persists them. They
+	// still belong in the plan as `delete` rows so the user sees what
+	// is going to happen and the safety gate can refuse them.
+	for _, f := range result.Deleted {
+		p.Rows = append(p.Rows, planRowFromLockFile(f, prevPaths))
+	}
 	// Stable, deterministic ordering by destination path so callers can
 	// snapshot-test the rendering.
 	sort.Slice(p.Rows, func(i, j int) bool {
@@ -146,6 +154,16 @@ func planRowFromLockFile(f lock.LockFile, prevPaths map[string]bool) PlanRow {
 		Dest:   f.Dest,
 	}
 	switch {
+	case status == "deleted":
+		row.Action = PlanDelete
+	case strings.HasPrefix(status, "delete-skipped"):
+		row.Action = PlanKeep
+		// Surface the reason (e.g. "local modified") so users can
+		// see why an upstream removal was not applied.
+		note := strings.TrimPrefix(status, "delete-skipped ")
+		note = strings.TrimPrefix(note, "(")
+		note = strings.TrimSuffix(note, ")")
+		row.Note = "delete skipped: " + note
 	case status == "unchanged":
 		row.Action = PlanKeep
 	case status == "kept":
@@ -220,7 +238,7 @@ func RenderPlanText(w io.Writer, p *Plan) {
 	// reads "→ 3 update" instead of "→ 0 add, 3 update, 0 keep, 0
 	// overwrite, 0 merge, 0 conflict".
 	counts := p.CountByAction()
-	order := []PlanAction{PlanAdd, PlanUpdate, PlanKeep, PlanOverwrite, PlanMerge, PlanConflict}
+	order := []PlanAction{PlanAdd, PlanUpdate, PlanKeep, PlanOverwrite, PlanMerge, PlanConflict, PlanDelete}
 	var parts []string
 	for _, a := range order {
 		if c := counts[a]; c > 0 {
@@ -272,6 +290,8 @@ func planMarker(a PlanAction) (string, string) {
 		return "⊕", "merge"
 	case PlanConflict:
 		return "✗", "conflict"
+	case PlanDelete:
+		return "-", "delete"
 	default:
 		return "?", string(a)
 	}

--- a/pkg/env/plan.go
+++ b/pkg/env/plan.go
@@ -22,7 +22,7 @@ const (
 	PlanOverwrite PlanAction = "overwrite" // local changes will be replaced by upstream
 	PlanMerge     PlanAction = "merge"     // 3-way merge applied (or would be), no conflict
 	PlanConflict  PlanAction = "conflict"  // 3-way merge produced conflict markers; needs manual resolution
-	PlanDelete    PlanAction = "delete"    // file existed in previous lock but no longer in upstream; will be removed
+	PlanDelete    PlanAction = "delete"    // file existed in previous lock but no longer in upstream; flagged for removal (Phase 3 plumbing only — actual on-disk removal lands in a follow-up against the gateApply layer)
 )
 
 // IsDestructive reports whether an action would lose user-owned content.
@@ -156,6 +156,15 @@ func planRowFromLockFile(f lock.LockFile, prevPaths map[string]bool) PlanRow {
 	switch {
 	case status == "deleted":
 		row.Action = PlanDelete
+	case strings.HasPrefix(status, "delete-noop"):
+		// File was orphaned upstream AND already missing on disk
+		// → nothing to do, render as a non-destructive keep with
+		// a note so the user understands why it's listed at all.
+		row.Action = PlanKeep
+		note := strings.TrimPrefix(status, "delete-noop ")
+		note = strings.TrimPrefix(note, "(")
+		note = strings.TrimSuffix(note, ")")
+		row.Note = "already gone: " + note
 	case strings.HasPrefix(status, "delete-skipped"):
 		row.Action = PlanKeep
 		// Surface the reason (e.g. "local modified") so users can

--- a/pkg/env/plan.go
+++ b/pkg/env/plan.go
@@ -164,7 +164,7 @@ func planRowFromLockFile(f lock.LockFile, prevPaths map[string]bool) PlanRow {
 		note := strings.TrimPrefix(status, "delete-noop ")
 		note = strings.TrimPrefix(note, "(")
 		note = strings.TrimSuffix(note, ")")
-		row.Note = "already gone: " + note
+		row.Note = note
 	case strings.HasPrefix(status, "delete-skipped"):
 		row.Action = PlanKeep
 		// Surface the reason (e.g. "local modified") so users can

--- a/pkg/env/plan_delete_test.go
+++ b/pkg/env/plan_delete_test.go
@@ -1,0 +1,98 @@
+package env
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/fentas/b/pkg/lock"
+)
+
+// TestPlanDeleteIsDestructive: Phase 3 of #125 adds `delete` to the
+// destructive set so strict mode refuses sync plans that would
+// remove files.
+func TestPlanDeleteIsDestructive(t *testing.T) {
+	if !PlanDelete.IsDestructive() {
+		t.Error("PlanDelete should be destructive")
+	}
+}
+
+// TestPlanFromResult_IncludesDeleteRows: orphan files on
+// result.Deleted must surface in the plan as `delete` rows so the
+// user sees them and the gate can refuse them.
+func TestPlanFromResult_IncludesDeleteRows(t *testing.T) {
+	result := &SyncResult{
+		Ref: "github.com/x/y",
+		Files: []lock.LockFile{
+			{Path: "kept.yaml", Dest: "kept.yaml", Status: "unchanged"},
+		},
+		Deleted: []lock.LockFile{
+			{Path: "old.yaml", Dest: "old.yaml", Status: "deleted"},
+		},
+	}
+	prev := &lock.EnvEntry{
+		Files: []lock.LockFile{
+			{Path: "kept.yaml"},
+			{Path: "old.yaml"},
+		},
+	}
+	p := PlanFromResult(result, prev)
+
+	var sawDelete bool
+	for _, r := range p.Rows {
+		if r.Action == PlanDelete && r.Dest == "old.yaml" {
+			sawDelete = true
+		}
+	}
+	if !sawDelete {
+		t.Errorf("expected a delete row for old.yaml, got rows: %+v", p.Rows)
+	}
+	if !p.HasDestructive() {
+		t.Errorf("plan with a delete row should be destructive")
+	}
+}
+
+// TestPlanFromResult_DeleteSkippedRendersAsKeep: when local has
+// modified the file, the delete is skipped. The plan should NOT show
+// a destructive row for it — it renders as keep with a note so the
+// user understands what happened.
+func TestPlanFromResult_DeleteSkippedRendersAsKeep(t *testing.T) {
+	result := &SyncResult{
+		Ref: "github.com/x/y",
+		Deleted: []lock.LockFile{
+			{Path: "modified.yaml", Dest: "modified.yaml", Status: "delete-skipped (local modified)"},
+		},
+	}
+	p := PlanFromResult(result, nil)
+
+	if len(p.Rows) != 1 {
+		t.Fatalf("want 1 row, got %d", len(p.Rows))
+	}
+	row := p.Rows[0]
+	if row.Action != PlanKeep {
+		t.Errorf("want PlanKeep, got %v", row.Action)
+	}
+	if !strings.Contains(row.Note, "local modified") {
+		t.Errorf("note should mention local modified, got %q", row.Note)
+	}
+	if p.HasDestructive() {
+		t.Errorf("a delete-skipped row must not be destructive")
+	}
+}
+
+// TestPlanRenderText_DeleteRow renders the new glyph + label.
+func TestPlanRenderText_DeleteRow(t *testing.T) {
+	p := &Plan{
+		Rows: []PlanRow{
+			{Action: PlanDelete, Dest: "gone.yaml"},
+		},
+	}
+	var sb strings.Builder
+	RenderPlanText(&sb, p)
+	out := sb.String()
+	if !strings.Contains(out, "delete") || !strings.Contains(out, "gone.yaml") {
+		t.Errorf("delete row missing in render:\n%s", out)
+	}
+	if !strings.Contains(out, "1 delete") {
+		t.Errorf("summary missing delete count:\n%s", out)
+	}
+}

--- a/pkg/env/sync_local_test.go
+++ b/pkg/env/sync_local_test.go
@@ -95,15 +95,15 @@ func TestSyncEnv_OrphanDetection_EmitsDeleteRows(t *testing.T) {
 		},
 	}
 
-	// Sub-case 1: orphan file exists on disk and matches the
-	// recorded SHA → should be "deleted" (or "deleted (dry-run)").
+	// Sub-case 1: orphan file exists on disk but its content does
+	// NOT match the recorded SHA (the consumer modified it locally).
+	// Expected status: "delete-skipped (local modified)" so the
+	// consumer's edits are preserved. The fake "deadbeef" SHA in
+	// prev guarantees the mismatch.
 	orphanPath := filepath.Join(project, "configs", "orphan.yaml")
 	if err := os.MkdirAll(filepath.Dir(orphanPath), 0755); err != nil {
 		t.Fatal(err)
 	}
-	// Write content matching the recorded SHA. Since we used a
-	// fake "deadbeef" SHA, write something with no chance of
-	// matching, then exercise the local-modified branch instead.
 	if err := os.WriteFile(orphanPath, []byte("local edits\n"), 0644); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/env/sync_local_test.go
+++ b/pkg/env/sync_local_test.go
@@ -55,6 +55,95 @@ func setupLocalBareRepo(t *testing.T) (string, string) {
 	return bare, strings.TrimSpace(string(commitOut))
 }
 
+// TestSyncEnv_OrphanDetection_EmitsDeleteRows is the integration
+// test for the #125 phase 3 orphan plumbing. We construct a previous
+// lock entry with an extra file that no longer exists in upstream,
+// run SyncEnv, and verify:
+//   - the orphan shows up in result.Deleted (NOT result.Files, so the
+//     lock writer never persists it)
+//   - the deleted file's status is "deleted" / "deleted (dry-run)"
+//     when local is unmodified
+//   - a locally modified orphan flips to "delete-skipped (local
+//     modified)"
+//   - a missing-on-disk orphan flips to "delete-noop (already gone)"
+func TestSyncEnv_OrphanDetection_EmitsDeleteRows(t *testing.T) {
+	bare, _ := setupLocalBareRepo(t)
+	project := t.TempDir()
+
+	cfg := EnvConfig{
+		Ref:      bare,
+		Strategy: StrategyReplace,
+		Files: map[string]envmatch.GlobConfig{
+			"cfg/*.yaml": {Dest: "configs"},
+		},
+	}
+
+	// Build a previous lock entry that records THREE files: the two
+	// real ones plus an orphan that was once tracked but is no
+	// longer in upstream. The previous commit is intentionally set
+	// to a fake hash so SyncEnv doesn't take the up-to-date
+	// shortcut and actually walks the orphan-detection branch.
+	prev := &lock.EnvEntry{
+		Ref:    bare,
+		Commit: "0000000000000000000000000000000000000000",
+		Files: []lock.LockFile{
+			{Path: "cfg/a.yaml", Dest: "configs/a.yaml"},
+			{Path: "cfg/b.yaml", Dest: "configs/b.yaml"},
+			{Path: "cfg/orphan.yaml", Dest: "configs/orphan.yaml", SHA256: "deadbeef"},
+		},
+	}
+
+	// Sub-case 1: orphan file exists on disk and matches the
+	// recorded SHA → should be "deleted" (or "deleted (dry-run)").
+	orphanPath := filepath.Join(project, "configs", "orphan.yaml")
+	if err := os.MkdirAll(filepath.Dir(orphanPath), 0755); err != nil {
+		t.Fatal(err)
+	}
+	// Write content matching the recorded SHA. Since we used a
+	// fake "deadbeef" SHA, write something with no chance of
+	// matching, then exercise the local-modified branch instead.
+	if err := os.WriteFile(orphanPath, []byte("local edits\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg.DryRun = true
+	res, err := SyncEnv(cfg, project, t.TempDir(), prev)
+	if err != nil {
+		t.Fatalf("SyncEnv: %v", err)
+	}
+	if len(res.Deleted) != 1 {
+		t.Fatalf("want 1 orphan in result.Deleted, got %d: %+v", len(res.Deleted), res.Deleted)
+	}
+	if res.Deleted[0].Path != "cfg/orphan.yaml" {
+		t.Errorf("orphan path = %q", res.Deleted[0].Path)
+	}
+	if !strings.Contains(res.Deleted[0].Status, "delete-skipped") {
+		t.Errorf("locally modified orphan should be delete-skipped, got %q", res.Deleted[0].Status)
+	}
+	// And it must NOT have leaked into result.Files (the lock writer
+	// reads .Files and would otherwise persist the orphan).
+	for _, f := range res.Files {
+		if f.Path == "cfg/orphan.yaml" {
+			t.Errorf("orphan leaked into result.Files: %+v", f)
+		}
+	}
+
+	// Sub-case 2: orphan file removed from disk → "delete-noop".
+	if err := os.Remove(orphanPath); err != nil {
+		t.Fatal(err)
+	}
+	res2, err := SyncEnv(cfg, project, t.TempDir(), prev)
+	if err != nil {
+		t.Fatalf("SyncEnv: %v", err)
+	}
+	if len(res2.Deleted) != 1 {
+		t.Fatalf("want 1 orphan, got %d", len(res2.Deleted))
+	}
+	if !strings.Contains(res2.Deleted[0].Status, "delete-noop") {
+		t.Errorf("missing-file orphan should be delete-noop, got %q", res2.Deleted[0].Status)
+	}
+}
+
 func TestSyncEnv_LocalReplace(t *testing.T) {
 	bare, _ := setupLocalBareRepo(t)
 	project := t.TempDir()

--- a/pkg/env/sync_local_test.go
+++ b/pkg/env/sync_local_test.go
@@ -1,6 +1,8 @@
 package env
 
 import (
+	"crypto/sha256"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -141,6 +143,33 @@ func TestSyncEnv_OrphanDetection_EmitsDeleteRows(t *testing.T) {
 	}
 	if !strings.Contains(res2.Deleted[0].Status, "delete-noop") {
 		t.Errorf("missing-file orphan should be delete-noop, got %q", res2.Deleted[0].Status)
+	}
+
+	// Sub-case 3: orphan file present and matches the recorded
+	// SHA (unmodified) → "deleted (dry-run)" without any
+	// skipped/noop suffix. Compute the SHA from real bytes so
+	// the lock and disk content actually agree.
+	body := []byte("untouched\n")
+	bodyHash := fmt.Sprintf("%x", sha256.Sum256(body))
+	if err := os.WriteFile(orphanPath, body, 0644); err != nil {
+		t.Fatal(err)
+	}
+	prevMatch := &lock.EnvEntry{
+		Ref:    bare,
+		Commit: "0000000000000000000000000000000000000000",
+		Files: []lock.LockFile{
+			{Path: "cfg/orphan.yaml", Dest: "configs/orphan.yaml", SHA256: bodyHash},
+		},
+	}
+	res3, err := SyncEnv(cfg, project, t.TempDir(), prevMatch)
+	if err != nil {
+		t.Fatalf("SyncEnv: %v", err)
+	}
+	if len(res3.Deleted) != 1 {
+		t.Fatalf("want 1 orphan, got %d", len(res3.Deleted))
+	}
+	if got := res3.Deleted[0].Status; !strings.HasPrefix(got, "deleted") || strings.Contains(got, "skipped") || strings.Contains(got, "noop") {
+		t.Errorf("unmodified orphan should be plain deleted, got %q", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Detects orphan files (in previous lock, gone from upstream) in \`SyncEnv\`
- Surfaces them as \`delete\` rows via a new \`SyncResult.Deleted\` field
- Adds \`PlanDelete\` to the destructive set so strict mode refuses sync plans that would remove files
- \`delete-skipped (local modified)\` renders as \`keep\` with a note (not destructive)
- Path-traversal check on every orphan dest

## Why
Phase 3 of issue #125 closes the silent-delete footgun: today, files removed from upstream simply disappear from the consumer's tree on the next sync with no warning. This PR adds the *plumbing* — detection, plan rendering, and safety-gate hookup.

## Out of scope (deliberate follow-ups)
- Actually removing the on-disk file. The flow runs \`SyncEnv\` twice (dry-run, then apply); deciding \"really delete?\" belongs next to the existing strict/prompt/auto logic in the CLI layer and will land as a follow-up against this PR.
- Honoring a \`b.kept:\` annotation for skipped-orphan suppression.

## Lock writer safety
\`Deleted\` is intentionally a separate slice from \`Files\` so the lock writer never persists empty-SHA rows. \`PlanFromResult\` merges them only at plan-render time.

## Test plan
- [x] \`go test ./pkg/env/... -count=1 -run 'PlanDelete|PlanFromResult|PlanRenderText'\`
- [x] full \`go test ./...\`
- [x] \`golangci-lint run ./pkg/env/...\`

Refs #125

🤖 Generated with [Claude Code](https://claude.com/claude-code)