### PR TITLE
feat(cli): b env resolve for merge conflicts (#125 phase 4)

### DIFF
--- a/pkg/cli/env.go
+++ b/pkg/cli/env.go
@@ -187,6 +187,7 @@ func NewEnvCmd(shared *SharedOptions) *cobra.Command {
 	cmd.AddCommand(NewEnvMatchCmd(shared))
 	cmd.AddCommand(NewEnvProfilesCmd(shared))
 	cmd.AddCommand(NewEnvAddCmd(shared))
+	cmd.AddCommand(NewEnvResolveCmd(shared))
 
 	return cmd
 }

--- a/pkg/cli/env_resolve.go
+++ b/pkg/cli/env_resolve.go
@@ -32,16 +32,14 @@ import (
 //	>>>>>>> upstream
 //
 // `--ours` keeps the local block, `--theirs` keeps the upstream block.
-// `--list` (default when no resolution flag is given) just enumerates
-// the affected files so the user can decide. Phase 4 of #125 also
-// covers in-place YAML comment markers; that conversion is a separate
-// PR — this command speaks the marker format that's actually written
-// today.
+// With neither flag set, the command just enumerates the affected
+// files so the user can decide. Phase 4 of #125 also covers in-place
+// YAML comment markers; that conversion is a separate PR — this
+// command speaks the marker format that's actually written today.
 type EnvResolveOptions struct {
 	*SharedOptions
 	Ours   bool
 	Theirs bool
-	List   bool
 }
 
 // NewEnvResolveCmd creates the env resolve subcommand.
@@ -73,7 +71,6 @@ scope to those envs; with no args all envs in the lock are checked.`,
 	}
 	cmd.Flags().BoolVar(&o.Ours, "ours", false, "rewrite each conflict by keeping the local side")
 	cmd.Flags().BoolVar(&o.Theirs, "theirs", false, "rewrite each conflict by keeping the upstream side")
-	cmd.Flags().BoolVar(&o.List, "list", false, "list conflicted files (default when no rewrite flag is set)")
 	return cmd
 }
 

--- a/pkg/cli/env_resolve.go
+++ b/pkg/cli/env_resolve.go
@@ -257,7 +257,15 @@ func hasConflictMarkers(b []byte) bool {
 		}
 	}
 	consume()
-	return hasStart && hasSep && hasEnd
+	// Treat the presence of a start marker as conflicted even
+	// without a closing >>>>>>> line. The point of `b env resolve`
+	// is to surface and clean up malformed merge state, so an
+	// unterminated region — which a partial manual edit can leave
+	// behind — needs to show up rather than be silently ignored.
+	// resolveConflictMarkers below will fail to find a complete
+	// region and either error out or return n == 0, which the Run
+	// loop already handles.
+	return hasStart
 }
 
 // resolveConflictMarkers walks a file containing git-style conflict

--- a/pkg/cli/env_resolve.go
+++ b/pkg/cli/env_resolve.go
@@ -10,6 +10,7 @@ import (
 	"github.com/fentas/goodies/templates"
 	"github.com/spf13/cobra"
 
+	"github.com/fentas/b/pkg/env"
 	"github.com/fentas/b/pkg/lock"
 )
 
@@ -92,20 +93,39 @@ func (o *EnvResolveOptions) Run(envFilter []string) error {
 		return nil
 	}
 
+	// Normalize each filter arg to its canonical "ref" or "ref#label"
+	// form so labeled envs can be targeted unambiguously when multiple
+	// lock entries share the same ref.
 	filter := make(map[string]bool, len(envFilter))
 	for _, k := range envFilter {
-		filter[k] = true
+		filter[envKey(k)] = true
 	}
 
+	projectRoot := o.ProjectRoot()
 	var totalConflicts, totalResolved int
-	for _, entry := range lk.Envs {
-		if len(filter) > 0 && !filter[entry.Ref] {
+	lockChanged := false
+	for ei := range lk.Envs {
+		entry := &lk.Envs[ei]
+		key := envKey(entry.Ref)
+		if entry.Label != "" {
+			key = entry.Ref + "#" + entry.Label
+		}
+		if len(filter) > 0 && !filter[key] {
 			continue
 		}
-		for _, f := range entry.Files {
+		for fi := range entry.Files {
+			f := &entry.Files[fi]
 			absDest := f.Dest
 			if !filepath.IsAbs(absDest) {
-				absDest = filepath.Join(o.ProjectRoot(), absDest)
+				absDest = filepath.Join(projectRoot, absDest)
+			}
+			absDest = filepath.Clean(absDest)
+			// Path-traversal check against projectRoot. A
+			// malicious or hand-edited lockfile must not let
+			// `b env resolve` read or write files outside the
+			// project root.
+			if err := env.ValidatePathUnderRoot(projectRoot, absDest); err != nil {
+				return fmt.Errorf("path traversal rejected for %s: %w", f.Dest, err)
 			}
 			data, err := os.ReadFile(absDest)
 			if err != nil {
@@ -118,7 +138,7 @@ func (o *EnvResolveOptions) Run(envFilter []string) error {
 				continue
 			}
 			totalConflicts++
-			fmt.Fprintf(o.IO.Out, "  %s → %s\n", entry.Ref, f.Dest)
+			fmt.Fprintf(o.IO.Out, "  %s → %s\n", key, f.Dest)
 
 			if !o.Ours && !o.Theirs {
 				continue
@@ -130,12 +150,28 @@ func (o *EnvResolveOptions) Run(envFilter []string) error {
 			if err := os.WriteFile(absDest, resolved, 0644); err != nil {
 				return fmt.Errorf("writing %s: %w", f.Dest, err)
 			}
+			// Update the lock entry's SHA so the next sync /
+			// `b verify` doesn't treat the resolved file as
+			// drifted. Without this step, `b env resolve` would
+			// produce a state where every status check still
+			// flagged the file as locally modified.
+			newHash, hashErr := lock.SHA256File(absDest)
+			if hashErr == nil && newHash != "" {
+				f.SHA256 = newHash
+				lockChanged = true
+			}
 			totalResolved += n
 			side := "upstream"
 			if o.Ours {
 				side = "local"
 			}
 			fmt.Fprintf(o.IO.Out, "    → resolved %d region(s) in favor of %s\n", n, side)
+		}
+	}
+
+	if lockChanged {
+		if err := lock.WriteLock(lockDir, lk, o.bVersion); err != nil {
+			return fmt.Errorf("updating b.lock after resolve: %w", err)
 		}
 	}
 
@@ -149,6 +185,15 @@ func (o *EnvResolveOptions) Run(envFilter []string) error {
 	}
 	fmt.Fprintf(o.IO.Out, "\nResolved %d region(s) across %d file(s).\n", totalResolved, totalConflicts)
 	return nil
+}
+
+// envKey returns the canonical "ref" or "ref#label" form for a user-
+// supplied env key. It's a no-op for keys that already include a label
+// or that don't need normalization; it exists so the filter matching
+// in Run can compare against the same canonical form the lock entries
+// produce.
+func envKey(s string) string {
+	return strings.TrimSpace(s)
 }
 
 // hasConflictMarkers reports whether the byte slice contains the
@@ -234,4 +279,3 @@ func resolveConflictMarkers(data []byte, keepOurs bool) ([]byte, int, error) {
 	}
 	return []byte(strings.Join(out, "\n")), count, nil
 }
-

--- a/pkg/cli/env_resolve.go
+++ b/pkg/cli/env_resolve.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"bytes"
+	"crypto/sha256"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -175,19 +176,12 @@ func (o *EnvResolveOptions) Run(envFilter []string) error {
 			}
 			// Update the lock entry's SHA so the next sync /
 			// `b verify` doesn't treat the resolved file as
-			// drifted. Without this step, `b env resolve` would
-			// produce a state where every status check still
-			// flagged the file as locally modified.
-			newHash, hashErr := lock.SHA256File(absDest)
-			if hashErr != nil {
-				resolveErrors = append(resolveErrors, fmt.Sprintf("rehashing %s: %v", f.Dest, hashErr))
-				continue
-			}
-			if newHash == "" {
-				resolveErrors = append(resolveErrors, fmt.Sprintf("rehashing %s: empty digest", f.Dest))
-				continue
-			}
-			f.SHA256 = newHash
+			// drifted. Hash the in-memory `resolved` bytes
+			// rather than re-reading the file: avoids the
+			// extra filesystem read AND closes a TOCTOU
+			// window where the file could be modified between
+			// the WriteFile and the rehash.
+			f.SHA256 = fmt.Sprintf("%x", sha256.Sum256(resolved))
 			lockChanged = true
 			totalResolved += n
 			side := "upstream"
@@ -308,32 +302,41 @@ func hasResolvableConflictMarkers(b []byte) bool {
 // keepOurs picks the block between `<<<<<<<` and the base or middle
 // marker; otherwise the block between `=======` and `>>>>>>>` wins.
 //
+// The implementation operates on []byte throughout (not a Go string)
+// so files containing non-UTF-8 bytes round-trip without corruption.
+// The separator marker is matched as the EXACT line `=======` (with
+// optional trailing `\r` for CRLF files) so a content line that
+// happens to start with `=======...` isn't misinterpreted as the
+// separator.
+//
 // Returns (resolved bytes, number of regions resolved, error).
 func resolveConflictMarkers(data []byte, keepOurs bool) ([]byte, int, error) {
-	lines := strings.Split(string(data), "\n")
-	var out []string
+	lines := bytes.Split(data, []byte("\n"))
+	var out [][]byte
 	var count int
+	startPrefix := []byte("<<<<<<<")
+	basePrefix := []byte("|||||||")
+	endPrefix := []byte(">>>>>>>")
 	i := 0
 	for i < len(lines) {
 		line := lines[i]
-		if !strings.HasPrefix(line, "<<<<<<<") {
+		if !bytes.HasPrefix(line, startPrefix) {
 			out = append(out, line)
 			i++
 			continue
 		}
-		// Found a conflict opening. Scan forward for the middle (|||||||
-		// or =======) and end (>>>>>>>) markers.
+		// Found a conflict opening. Scan forward for the middle
+		// (||||||| or =======) and end (>>>>>>>) markers.
 		startOurs := i + 1
 		var endOurs, startTheirs int
 		var endTheirs int
 		j := startOurs
-		// First search for `|||||||` (diff3 base) or `=======`.
 		for j < len(lines) {
-			if strings.HasPrefix(lines[j], "|||||||") {
+			if bytes.HasPrefix(lines[j], basePrefix) {
 				endOurs = j
 				// Skip the base section to the `=======`.
 				k := j + 1
-				for k < len(lines) && !strings.HasPrefix(lines[k], "=======") {
+				for k < len(lines) && !isSeparatorLine(lines[k]) {
 					k++
 				}
 				if k >= len(lines) {
@@ -342,7 +345,7 @@ func resolveConflictMarkers(data []byte, keepOurs bool) ([]byte, int, error) {
 				startTheirs = k + 1
 				break
 			}
-			if strings.HasPrefix(lines[j], "=======") {
+			if isSeparatorLine(lines[j]) {
 				endOurs = j
 				startTheirs = j + 1
 				break
@@ -354,7 +357,7 @@ func resolveConflictMarkers(data []byte, keepOurs bool) ([]byte, int, error) {
 		}
 		// Find the closing marker.
 		k := startTheirs
-		for k < len(lines) && !strings.HasPrefix(lines[k], ">>>>>>>") {
+		for k < len(lines) && !bytes.HasPrefix(lines[k], endPrefix) {
 			k++
 		}
 		if k >= len(lines) {
@@ -369,5 +372,14 @@ func resolveConflictMarkers(data []byte, keepOurs bool) ([]byte, int, error) {
 		count++
 		i = endTheirs + 1
 	}
-	return []byte(strings.Join(out, "\n")), count, nil
+	return bytes.Join(out, []byte("\n")), count, nil
+}
+
+// isSeparatorLine matches the exact `=======` separator line, with
+// optional trailing `\r` for CRLF files. We deliberately do NOT use
+// HasPrefix here so a content line that starts with `=======...`
+// (e.g. a markdown rule that happens to be inside a conflict
+// region's "ours" side) isn't misinterpreted.
+func isSeparatorLine(line []byte) bool {
+	return bytes.Equal(line, []byte("=======")) || bytes.Equal(line, []byte("=======\r"))
 }

--- a/pkg/cli/env_resolve.go
+++ b/pkg/cli/env_resolve.go
@@ -1,0 +1,237 @@
+package cli
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/fentas/goodies/templates"
+	"github.com/spf13/cobra"
+
+	"github.com/fentas/b/pkg/lock"
+)
+
+// EnvResolveOptions holds options for `b env resolve`.
+//
+// The command lists files that contain unresolved git-style conflict
+// markers (left there by `b env update` after a 3-way merge couldn't
+// auto-merge a hunk) and optionally rewrites them in bulk by picking
+// one side of every conflict region.
+//
+// Conflict marker shape (the `git merge-file --diff3` output b uses):
+//
+//	<<<<<<< local
+//	  consumer's version
+//	||||||| base
+//	  base version
+//	=======
+//	  upstream version
+//	>>>>>>> upstream
+//
+// `--ours` keeps the local block, `--theirs` keeps the upstream block.
+// `--list` (default when no resolution flag is given) just enumerates
+// the affected files so the user can decide. Phase 4 of #125 also
+// covers in-place YAML comment markers; that conversion is a separate
+// PR — this command speaks the marker format that's actually written
+// today.
+type EnvResolveOptions struct {
+	*SharedOptions
+	Ours   bool
+	Theirs bool
+	List   bool
+}
+
+// NewEnvResolveCmd creates the env resolve subcommand.
+func NewEnvResolveCmd(shared *SharedOptions) *cobra.Command {
+	o := &EnvResolveOptions{SharedOptions: shared}
+	cmd := &cobra.Command{
+		Use:   "resolve [env...]",
+		Short: "List or auto-resolve merge conflicts left by `b env update`",
+		Long: `Inspect synced env files for unresolved git-style merge conflict markers
+and optionally pick a side in bulk.
+
+Without --ours or --theirs the command lists every conflicted file. With
+either flag, the listed files are rewritten in place by keeping that
+side of every conflict region. Pass one or more env keys to limit the
+scope to those envs; with no args all envs in the lock are checked.`,
+		Example: templates.Examples(`
+			# list conflicts across all envs
+			b env resolve
+
+			# accept upstream for every conflict in one env
+			b env resolve --theirs github.com/org/infra
+
+			# accept local everywhere
+			b env resolve --ours
+		`),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return o.Run(args)
+		},
+	}
+	cmd.Flags().BoolVar(&o.Ours, "ours", false, "rewrite each conflict by keeping the local side")
+	cmd.Flags().BoolVar(&o.Theirs, "theirs", false, "rewrite each conflict by keeping the upstream side")
+	cmd.Flags().BoolVar(&o.List, "list", false, "list conflicted files (default when no rewrite flag is set)")
+	return cmd
+}
+
+// Run executes env resolve.
+func (o *EnvResolveOptions) Run(envFilter []string) error {
+	if o.Ours && o.Theirs {
+		return fmt.Errorf("--ours and --theirs are mutually exclusive")
+	}
+
+	lockDir := o.LockDir()
+	lk, err := lock.ReadLock(lockDir)
+	if err != nil {
+		return err
+	}
+	if lk == nil || len(lk.Envs) == 0 {
+		fmt.Fprintln(o.IO.Out, "No envs in lock.")
+		return nil
+	}
+
+	filter := make(map[string]bool, len(envFilter))
+	for _, k := range envFilter {
+		filter[k] = true
+	}
+
+	var totalConflicts, totalResolved int
+	for _, entry := range lk.Envs {
+		if len(filter) > 0 && !filter[entry.Ref] {
+			continue
+		}
+		for _, f := range entry.Files {
+			absDest := f.Dest
+			if !filepath.IsAbs(absDest) {
+				absDest = filepath.Join(o.ProjectRoot(), absDest)
+			}
+			data, err := os.ReadFile(absDest)
+			if err != nil {
+				if os.IsNotExist(err) {
+					continue
+				}
+				return fmt.Errorf("reading %s: %w", f.Dest, err)
+			}
+			if !hasConflictMarkers(data) {
+				continue
+			}
+			totalConflicts++
+			fmt.Fprintf(o.IO.Out, "  %s → %s\n", entry.Ref, f.Dest)
+
+			if !o.Ours && !o.Theirs {
+				continue
+			}
+			resolved, n, rerr := resolveConflictMarkers(data, o.Ours)
+			if rerr != nil {
+				return fmt.Errorf("resolving %s: %w", f.Dest, rerr)
+			}
+			if err := os.WriteFile(absDest, resolved, 0644); err != nil {
+				return fmt.Errorf("writing %s: %w", f.Dest, err)
+			}
+			totalResolved += n
+			side := "upstream"
+			if o.Ours {
+				side = "local"
+			}
+			fmt.Fprintf(o.IO.Out, "    → resolved %d region(s) in favor of %s\n", n, side)
+		}
+	}
+
+	if totalConflicts == 0 {
+		fmt.Fprintln(o.IO.Out, "No conflicts found.")
+		return nil
+	}
+	if !o.Ours && !o.Theirs {
+		fmt.Fprintf(o.IO.Out, "\n%d conflicted file(s). Re-run with --ours or --theirs to resolve in bulk, or edit them manually.\n", totalConflicts)
+		return nil
+	}
+	fmt.Fprintf(o.IO.Out, "\nResolved %d region(s) across %d file(s).\n", totalResolved, totalConflicts)
+	return nil
+}
+
+// hasConflictMarkers reports whether the byte slice contains the
+// minimum signature of a git merge-file conflict region. We require
+// all three markers because partial matches can be legitimate file
+// content (e.g. a markdown rule like `=======`).
+func hasConflictMarkers(b []byte) bool {
+	return bytes.Contains(b, []byte("<<<<<<<")) &&
+		bytes.Contains(b, []byte("=======")) &&
+		bytes.Contains(b, []byte(">>>>>>>"))
+}
+
+// resolveConflictMarkers walks a file containing git-style conflict
+// regions and rewrites it by keeping one side of every region. It
+// supports both 2-way (`<<<<<<< / ======= / >>>>>>>`) and diff3
+// (`<<<<<<< / ||||||| / ======= / >>>>>>>`) marker forms — `b env
+// update` writes the diff3 form, but the parser tolerates either so
+// hand-edited files still resolve cleanly.
+//
+// keepOurs picks the block between `<<<<<<<` and the base or middle
+// marker; otherwise the block between `=======` and `>>>>>>>` wins.
+//
+// Returns (resolved bytes, number of regions resolved, error).
+func resolveConflictMarkers(data []byte, keepOurs bool) ([]byte, int, error) {
+	lines := strings.Split(string(data), "\n")
+	var out []string
+	var count int
+	i := 0
+	for i < len(lines) {
+		line := lines[i]
+		if !strings.HasPrefix(line, "<<<<<<<") {
+			out = append(out, line)
+			i++
+			continue
+		}
+		// Found a conflict opening. Scan forward for the middle (|||||||
+		// or =======) and end (>>>>>>>) markers.
+		startOurs := i + 1
+		var endOurs, startTheirs int
+		var endTheirs int
+		j := startOurs
+		// First search for `|||||||` (diff3 base) or `=======`.
+		for j < len(lines) {
+			if strings.HasPrefix(lines[j], "|||||||") {
+				endOurs = j
+				// Skip the base section to the `=======`.
+				k := j + 1
+				for k < len(lines) && !strings.HasPrefix(lines[k], "=======") {
+					k++
+				}
+				if k >= len(lines) {
+					return nil, 0, fmt.Errorf("unterminated conflict region at line %d", i+1)
+				}
+				startTheirs = k + 1
+				break
+			}
+			if strings.HasPrefix(lines[j], "=======") {
+				endOurs = j
+				startTheirs = j + 1
+				break
+			}
+			j++
+		}
+		if j >= len(lines) {
+			return nil, 0, fmt.Errorf("unterminated conflict region at line %d", i+1)
+		}
+		// Find the closing marker.
+		k := startTheirs
+		for k < len(lines) && !strings.HasPrefix(lines[k], ">>>>>>>") {
+			k++
+		}
+		if k >= len(lines) {
+			return nil, 0, fmt.Errorf("missing closing marker for conflict at line %d", i+1)
+		}
+		endTheirs = k
+		if keepOurs {
+			out = append(out, lines[startOurs:endOurs]...)
+		} else {
+			out = append(out, lines[startTheirs:endTheirs]...)
+		}
+		count++
+		i = endTheirs + 1
+	}
+	return []byte(strings.Join(out, "\n")), count, nil
+}
+

--- a/pkg/cli/env_resolve.go
+++ b/pkg/cli/env_resolve.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"bufio"
 	"bytes"
 	"fmt"
 	"os"
@@ -144,6 +145,15 @@ func (o *EnvResolveOptions) Run(envFilter []string) error {
 			if rerr != nil {
 				return fmt.Errorf("resolving %s: %w", f.Dest, rerr)
 			}
+			if n == 0 {
+				// hasConflictMarkers said yes but the parser
+				// found no real regions (false-positive
+				// detection on a pathological input). Skip
+				// the write and lock update so we don't
+				// touch a file that doesn't actually need
+				// resolving.
+				continue
+			}
 			if err := os.WriteFile(absDest, resolved, 0644); err != nil {
 				return fmt.Errorf("writing %s: %w", f.Dest, err)
 			}
@@ -196,14 +206,34 @@ func envKey(s string) string {
 	return strings.TrimSpace(s)
 }
 
-// hasConflictMarkers reports whether the byte slice contains the
-// minimum signature of a git merge-file conflict region. We require
-// all three markers because partial matches can be legitimate file
-// content (e.g. a markdown rule like `=======`).
+// hasConflictMarkers reports whether the byte slice contains a git
+// merge-file conflict region. The check is line-anchored (and
+// tolerates a trailing CR for CRLF files) so a marker substring
+// inside a YAML string literal or a markdown rule like `=======`
+// can't trigger a false positive — Run() would otherwise rewrite
+// a file that has no real conflicts.
 func hasConflictMarkers(b []byte) bool {
-	return bytes.Contains(b, []byte("<<<<<<<")) &&
-		bytes.Contains(b, []byte("=======")) &&
-		bytes.Contains(b, []byte(">>>>>>>"))
+	var hasStart, hasSep, hasEnd bool
+	scanner := bufio.NewScanner(bytes.NewReader(b))
+	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if n := len(line); n > 0 && line[n-1] == '\r' {
+			line = line[:n-1]
+		}
+		switch {
+		case bytes.HasPrefix(line, []byte("<<<<<<< ")):
+			hasStart = true
+		case bytes.Equal(line, []byte("=======")):
+			hasSep = true
+		case bytes.HasPrefix(line, []byte(">>>>>>> ")):
+			hasEnd = true
+		}
+		if hasStart && hasSep && hasEnd {
+			return true
+		}
+	}
+	return false
 }
 
 // resolveConflictMarkers walks a file containing git-style conflict

--- a/pkg/cli/env_resolve.go
+++ b/pkg/cli/env_resolve.go
@@ -234,12 +234,16 @@ func hasConflictMarkers(b []byte) bool {
 		if n := len(line); n > 0 && line[n-1] == '\r' {
 			line = line[:n-1]
 		}
+		// Match the same loose prefix that resolveConflictMarkers
+		// uses: a bare `<<<<<<<` line (no label suffix) is valid
+		// hand-edited conflict and the resolver will rewrite it,
+		// so the detector must agree.
 		switch {
-		case bytes.HasPrefix(line, []byte("<<<<<<< ")):
+		case bytes.HasPrefix(line, []byte("<<<<<<<")):
 			hasStart = true
 		case bytes.Equal(line, []byte("=======")):
 			hasSep = true
-		case bytes.HasPrefix(line, []byte(">>>>>>> ")):
+		case bytes.HasPrefix(line, []byte(">>>>>>>")):
 			hasEnd = true
 		}
 	}

--- a/pkg/cli/env_resolve.go
+++ b/pkg/cli/env_resolve.go
@@ -103,6 +103,13 @@ func (o *EnvResolveOptions) Run(envFilter []string) error {
 	projectRoot := o.ProjectRoot()
 	var totalConflicts, totalResolved int
 	lockChanged := false
+	// Collect per-file errors instead of returning early. Bulk
+	// resolve mutates files on disk and the lock in memory; bailing
+	// halfway through would leave the working tree partially
+	// resolved while the lock still pointed at stale SHAs. Walk the
+	// whole list, persist the lock once at the end, then surface
+	// the aggregate error.
+	var resolveErrors []string
 	for ei := range lk.Envs {
 		entry := &lk.Envs[ei]
 		key := envKey(entry.Ref)
@@ -124,16 +131,18 @@ func (o *EnvResolveOptions) Run(envFilter []string) error {
 			// `b env resolve` read or write files outside the
 			// project root.
 			if err := env.ValidatePathUnderRoot(projectRoot, absDest); err != nil {
-				return fmt.Errorf("path traversal rejected for %s: %w", f.Dest, err)
+				resolveErrors = append(resolveErrors, fmt.Sprintf("path traversal rejected for %s: %v", f.Dest, err))
+				continue
 			}
 			data, err := os.ReadFile(absDest)
 			if err != nil {
 				if os.IsNotExist(err) {
 					continue
 				}
-				return fmt.Errorf("reading %s: %w", f.Dest, err)
+				resolveErrors = append(resolveErrors, fmt.Sprintf("reading %s: %v", f.Dest, err))
+				continue
 			}
-			if !hasConflictMarkers(data) {
+			if !hasResolvableConflictMarkers(data) {
 				continue
 			}
 
@@ -152,7 +161,8 @@ func (o *EnvResolveOptions) Run(envFilter []string) error {
 			}
 			resolved, n, rerr := resolveConflictMarkers(data, o.Ours)
 			if rerr != nil {
-				return fmt.Errorf("resolving %s: %w", f.Dest, rerr)
+				resolveErrors = append(resolveErrors, fmt.Sprintf("resolving %s: %v", f.Dest, rerr))
+				continue
 			}
 			if n == 0 {
 				continue
@@ -160,7 +170,8 @@ func (o *EnvResolveOptions) Run(envFilter []string) error {
 			totalConflicts++
 			fmt.Fprintf(o.IO.Out, "  %s → %s\n", key, f.Dest)
 			if err := os.WriteFile(absDest, resolved, 0644); err != nil {
-				return fmt.Errorf("writing %s: %w", f.Dest, err)
+				resolveErrors = append(resolveErrors, fmt.Sprintf("writing %s: %v", f.Dest, err))
+				continue
 			}
 			// Update the lock entry's SHA so the next sync /
 			// `b verify` doesn't treat the resolved file as
@@ -169,10 +180,12 @@ func (o *EnvResolveOptions) Run(envFilter []string) error {
 			// flagged the file as locally modified.
 			newHash, hashErr := lock.SHA256File(absDest)
 			if hashErr != nil {
-				return fmt.Errorf("rehashing %s after resolve: %w", f.Dest, hashErr)
+				resolveErrors = append(resolveErrors, fmt.Sprintf("rehashing %s: %v", f.Dest, hashErr))
+				continue
 			}
 			if newHash == "" {
-				return fmt.Errorf("rehashing %s after resolve: empty digest", f.Dest)
+				resolveErrors = append(resolveErrors, fmt.Sprintf("rehashing %s: empty digest", f.Dest))
+				continue
 			}
 			f.SHA256 = newHash
 			lockChanged = true
@@ -185,10 +198,18 @@ func (o *EnvResolveOptions) Run(envFilter []string) error {
 		}
 	}
 
+	// Persist the lock BEFORE returning any error. If we got
+	// halfway through a bulk resolve and then hit a write failure,
+	// the working tree already has resolved files; the lock must
+	// reflect that to avoid leaving stale SHAs that would make
+	// every future status check report drift.
 	if lockChanged {
 		if err := lock.WriteLock(lockDir, lk, o.bVersion); err != nil {
-			return fmt.Errorf("updating b.lock after resolve: %w", err)
+			resolveErrors = append(resolveErrors, fmt.Sprintf("updating b.lock: %v", err))
 		}
+	}
+	if len(resolveErrors) > 0 {
+		return fmt.Errorf("env resolve: %d error(s):\n  - %s", len(resolveErrors), strings.Join(resolveErrors, "\n  - "))
 	}
 
 	if totalConflicts == 0 {
@@ -211,22 +232,27 @@ func envKey(s string) string {
 	return strings.TrimSpace(s)
 }
 
-// hasConflictMarkers reports whether the byte slice contains a git
-// merge-file conflict region. The check is line-anchored (and
-// tolerates a trailing CR for CRLF files) so a marker substring
-// inside a YAML string literal or a markdown rule like `=======`
-// can't trigger a false positive — Run() would otherwise rewrite
-// a file that has no real conflicts.
+// hasResolvableConflictMarkers reports whether the byte slice
+// contains a git merge-file conflict region that env resolve can
+// rewrite. The check is line-anchored (and tolerates trailing CR for
+// CRLF files) so a marker substring inside a YAML string literal or
+// a markdown rule like `=======` can't trigger a false positive —
+// Run() would otherwise rewrite a file that has no real conflicts.
 //
-// Implementation note: a tiny state machine instead of bufio.Scanner.
-// Scanner has a max-token-size cap that would silently fail on very
-// long lines (SOPS blobs, minified JSON, lockfiles). The state
-// machine bounds per-line state at conflictPendingMax bytes — the
-// markers we care about are at most 16 bytes — so a degenerate
-// single long line is harmless regardless of file size.
-const conflictPendingMax = 64
-
-func hasConflictMarkers(b []byte) bool {
+// This is intentionally distinct from env.go's hasConflictMarkers,
+// which is the strict env-status detector. env resolve needs a
+// looser detector that:
+//   - matches bare `<<<<<<<` / `>>>>>>>` lines (no label suffix)
+//     because resolveConflictMarkers' parser uses the same loose
+//     prefix
+//   - reports an unterminated region (start marker but no closing
+//     line) as conflicted, so the cleanup command surfaces files
+//     left in a half-merged state by a partial manual edit
+//
+// env status uses the strict variant so partial files (e.g. a
+// document that legitimately starts with a `<<<<<<<` literal in a
+// YAML string) don't show up as drifted.
+func hasResolvableConflictMarkers(b []byte) bool {
 	var hasStart, hasSep, hasEnd bool
 	pending := make([]byte, 0, conflictPendingMax)
 	consume := func() {

--- a/pkg/cli/env_resolve.go
+++ b/pkg/cli/env_resolve.go
@@ -1,7 +1,6 @@
 package cli
 
 import (
-	"bufio"
 	"bytes"
 	"fmt"
 	"os"
@@ -91,9 +90,11 @@ func (o *EnvResolveOptions) Run(envFilter []string) error {
 		return nil
 	}
 
-	// Normalize each filter arg to its canonical "ref" or "ref#label"
-	// form so labeled envs can be targeted unambiguously when multiple
-	// lock entries share the same ref.
+	// Trim whitespace off each filter arg so the matching loop
+	// below can compare against the canonical "ref" / "ref#label"
+	// form built from the lock entry side. envKey is intentionally
+	// just TrimSpace; the canonical form is built per-entry in the
+	// loop, not here.
 	filter := make(map[string]bool, len(envFilter))
 	for _, k := range envFilter {
 		filter[envKey(k)] = true
@@ -135,10 +136,18 @@ func (o *EnvResolveOptions) Run(envFilter []string) error {
 			if !hasConflictMarkers(data) {
 				continue
 			}
-			totalConflicts++
-			fmt.Fprintf(o.IO.Out, "  %s → %s\n", key, f.Dest)
 
+			// In list-only mode (no --ours/--theirs) we trust
+			// the line-anchored marker scan and just print the
+			// file. In rewrite mode we need the parser to find
+			// at least one real region; otherwise the marker
+			// scan was a false positive on a pathological
+			// input and we leave the file alone WITHOUT
+			// counting it as a conflict (so the summary line
+			// reflects what was actually actionable).
 			if !o.Ours && !o.Theirs {
+				totalConflicts++
+				fmt.Fprintf(o.IO.Out, "  %s → %s\n", key, f.Dest)
 				continue
 			}
 			resolved, n, rerr := resolveConflictMarkers(data, o.Ours)
@@ -146,14 +155,10 @@ func (o *EnvResolveOptions) Run(envFilter []string) error {
 				return fmt.Errorf("resolving %s: %w", f.Dest, rerr)
 			}
 			if n == 0 {
-				// hasConflictMarkers said yes but the parser
-				// found no real regions (false-positive
-				// detection on a pathological input). Skip
-				// the write and lock update so we don't
-				// touch a file that doesn't actually need
-				// resolving.
 				continue
 			}
+			totalConflicts++
+			fmt.Fprintf(o.IO.Out, "  %s → %s\n", key, f.Dest)
 			if err := os.WriteFile(absDest, resolved, 0644); err != nil {
 				return fmt.Errorf("writing %s: %w", f.Dest, err)
 			}
@@ -212,12 +217,20 @@ func envKey(s string) string {
 // inside a YAML string literal or a markdown rule like `=======`
 // can't trigger a false positive — Run() would otherwise rewrite
 // a file that has no real conflicts.
+//
+// Implementation note: a tiny state machine instead of bufio.Scanner.
+// Scanner has a max-token-size cap that would silently fail on very
+// long lines (SOPS blobs, minified JSON, lockfiles). The state
+// machine bounds per-line state at conflictPendingMax bytes — the
+// markers we care about are at most 16 bytes — so a degenerate
+// single long line is harmless regardless of file size.
+const conflictPendingMax = 64
+
 func hasConflictMarkers(b []byte) bool {
 	var hasStart, hasSep, hasEnd bool
-	scanner := bufio.NewScanner(bytes.NewReader(b))
-	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
-	for scanner.Scan() {
-		line := scanner.Bytes()
+	pending := make([]byte, 0, conflictPendingMax)
+	consume := func() {
+		line := pending
 		if n := len(line); n > 0 && line[n-1] == '\r' {
 			line = line[:n-1]
 		}
@@ -229,11 +242,22 @@ func hasConflictMarkers(b []byte) bool {
 		case bytes.HasPrefix(line, []byte(">>>>>>> ")):
 			hasEnd = true
 		}
-		if hasStart && hasSep && hasEnd {
-			return true
+	}
+	for _, c := range b {
+		if c == '\n' {
+			consume()
+			pending = pending[:0]
+			if hasStart && hasSep && hasEnd {
+				return true
+			}
+			continue
+		}
+		if len(pending) < conflictPendingMax {
+			pending = append(pending, c)
 		}
 	}
-	return false
+	consume()
+	return hasStart && hasSep && hasEnd
 }
 
 // resolveConflictMarkers walks a file containing git-style conflict

--- a/pkg/cli/env_resolve.go
+++ b/pkg/cli/env_resolve.go
@@ -153,10 +153,14 @@ func (o *EnvResolveOptions) Run(envFilter []string) error {
 			// produce a state where every status check still
 			// flagged the file as locally modified.
 			newHash, hashErr := lock.SHA256File(absDest)
-			if hashErr == nil && newHash != "" {
-				f.SHA256 = newHash
-				lockChanged = true
+			if hashErr != nil {
+				return fmt.Errorf("rehashing %s after resolve: %w", f.Dest, hashErr)
 			}
+			if newHash == "" {
+				return fmt.Errorf("rehashing %s after resolve: empty digest", f.Dest)
+			}
+			f.SHA256 = newHash
+			lockChanged = true
 			totalResolved += n
 			side := "upstream"
 			if o.Ours {
@@ -184,11 +188,10 @@ func (o *EnvResolveOptions) Run(envFilter []string) error {
 	return nil
 }
 
-// envKey returns the canonical "ref" or "ref#label" form for a user-
-// supplied env key. It's a no-op for keys that already include a label
-// or that don't need normalization; it exists so the filter matching
-// in Run can compare against the same canonical form the lock entries
-// produce.
+// envKey trims surrounding whitespace from a user-supplied env key.
+// The matching loop in Run already builds the canonical "ref" /
+// "ref#label" form from the lock entry side, so this helper only
+// needs to neutralize stray whitespace before comparing.
 func envKey(s string) string {
 	return strings.TrimSpace(s)
 }

--- a/pkg/cli/env_resolve_test.go
+++ b/pkg/cli/env_resolve_test.go
@@ -218,13 +218,24 @@ func TestEnvResolveRun_PathTraversalRejected(t *testing.T) {
 	}
 }
 
-// TestHasConflictMarkers requires all three signature pieces so a
-// markdown rule like `=======` alone doesn't trip the detector.
+// TestHasConflictMarkers exercises the line-anchored detector.
+// A markdown rule like `=======` alone must not trip the detector,
+// but an unterminated region (start marker with no closing line)
+// MUST be reported so `b env resolve` surfaces files left in a
+// half-merged state by a partial manual edit.
 func TestHasConflictMarkers(t *testing.T) {
 	if hasConflictMarkers([]byte("=======\n")) {
 		t.Error("=======-only should not be a conflict")
 	}
 	if !hasConflictMarkers([]byte("<<<<<<< local\nx\n=======\ny\n>>>>>>> upstream\n")) {
 		t.Error("full conflict not detected")
+	}
+	// Unterminated region: start marker, no closing >>>>>>>.
+	if !hasConflictMarkers([]byte("<<<<<<< local\nleft over\n")) {
+		t.Error("unterminated conflict region should be detected")
+	}
+	// Stray >>>>>>> with no opening should NOT trip the detector.
+	if hasConflictMarkers([]byte(">>>>>>> stray\n")) {
+		t.Error("stray closing marker should not be a conflict")
 	}
 }

--- a/pkg/cli/env_resolve_test.go
+++ b/pkg/cli/env_resolve_test.go
@@ -154,6 +154,7 @@ func TestEnvResolveRun_RewritesFileAndUpdatesLock(t *testing.T) {
 		SharedOptions: &SharedOptions{
 			IO:               &streams.IO{Out: &out, ErrOut: &bytes.Buffer{}},
 			loadedConfigPath: filepath.Join(tmp, "b.yaml"),
+			bVersion:         "test",
 		},
 		Theirs: true,
 	}
@@ -205,6 +206,7 @@ func TestEnvResolveRun_PathTraversalRejected(t *testing.T) {
 		SharedOptions: &SharedOptions{
 			IO:               &streams.IO{Out: &out, ErrOut: &bytes.Buffer{}},
 			loadedConfigPath: filepath.Join(tmp, "b.yaml"),
+			bVersion:         "test",
 		},
 	}
 	err := o.Run(nil)

--- a/pkg/cli/env_resolve_test.go
+++ b/pkg/cli/env_resolve_test.go
@@ -166,7 +166,7 @@ func TestEnvResolveRun_RewritesFileAndUpdatesLock(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if hasConflictMarkers(got) {
+	if hasResolvableConflictMarkers(got) {
 		t.Errorf("conflict markers not stripped:\n%s", got)
 	}
 	if !strings.Contains(string(got), "ther") {
@@ -224,24 +224,24 @@ func TestEnvResolveRun_PathTraversalRejected(t *testing.T) {
 // MUST be reported so `b env resolve` surfaces files left in a
 // half-merged state by a partial manual edit.
 func TestHasConflictMarkers(t *testing.T) {
-	if hasConflictMarkers([]byte("=======\n")) {
+	if hasResolvableConflictMarkers([]byte("=======\n")) {
 		t.Error("=======-only should not be a conflict")
 	}
-	if !hasConflictMarkers([]byte("<<<<<<< local\nx\n=======\ny\n>>>>>>> upstream\n")) {
+	if !hasResolvableConflictMarkers([]byte("<<<<<<< local\nx\n=======\ny\n>>>>>>> upstream\n")) {
 		t.Error("full conflict not detected")
 	}
 	// Unterminated region: start marker, no closing >>>>>>>.
-	if !hasConflictMarkers([]byte("<<<<<<< local\nleft over\n")) {
+	if !hasResolvableConflictMarkers([]byte("<<<<<<< local\nleft over\n")) {
 		t.Error("unterminated conflict region should be detected")
 	}
 	// Stray >>>>>>> with no opening should NOT trip the detector.
-	if hasConflictMarkers([]byte(">>>>>>> stray\n")) {
+	if hasResolvableConflictMarkers([]byte(">>>>>>> stray\n")) {
 		t.Error("stray closing marker should not be a conflict")
 	}
 	// Bare markers without a label suffix (hand-edited form)
 	// MUST be detected — resolveConflictMarkers uses the same
 	// loose prefix and will happily rewrite them.
-	if !hasConflictMarkers([]byte("<<<<<<<\nx\n=======\ny\n>>>>>>>\n")) {
+	if !hasResolvableConflictMarkers([]byte("<<<<<<<\nx\n=======\ny\n>>>>>>>\n")) {
 		t.Error("bare-marker conflict (no label suffix) should be detected")
 	}
 }

--- a/pkg/cli/env_resolve_test.go
+++ b/pkg/cli/env_resolve_test.go
@@ -1,8 +1,15 @@
 package cli
 
 import (
+	"bytes"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/fentas/goodies/streams"
+
+	"github.com/fentas/b/pkg/lock"
 )
 
 // TestResolveConflictMarkers_Diff3KeepOurs handles the diff3-format
@@ -107,6 +114,105 @@ func TestResolveConflictMarkers_Unterminated(t *testing.T) {
 	_, _, err := resolveConflictMarkers(in, true)
 	if err == nil {
 		t.Error("expected error for unterminated region")
+	}
+}
+
+// TestEnvResolveRun_RewritesFileAndUpdatesLock is the end-to-end
+// test the round-2 reviewer asked for. It writes a fake lockfile
+// pointing at a temp project file containing diff3 conflict
+// markers, runs `env resolve --theirs`, and checks that:
+//   - the file on disk no longer contains the markers
+//   - the lock entry's SHA was updated to match the new on-disk hash
+func TestEnvResolveRun_RewritesFileAndUpdatesLock(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("PATH_BASE", tmp)
+	conflicted := []byte("a\n<<<<<<< local\nour\n=======\nther\n>>>>>>> upstream\nz\n")
+	destRel := "configs/a.yaml"
+	destAbs := filepath.Join(tmp, destRel)
+	if err := os.MkdirAll(filepath.Dir(destAbs), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(destAbs, conflicted, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	lk := &lock.Lock{
+		Version: 1,
+		Envs: []lock.EnvEntry{{
+			Ref: "github.com/org/infra",
+			Files: []lock.LockFile{
+				{Path: "configs/a.yaml", Dest: destRel, SHA256: "stale-sha"},
+			},
+		}},
+	}
+	if err := lock.WriteLock(tmp, lk, "test"); err != nil {
+		t.Fatal(err)
+	}
+
+	var out bytes.Buffer
+	o := &EnvResolveOptions{
+		SharedOptions: &SharedOptions{
+			IO:               &streams.IO{Out: &out, ErrOut: &bytes.Buffer{}},
+			loadedConfigPath: filepath.Join(tmp, "b.yaml"),
+		},
+		Theirs: true,
+	}
+	if err := o.Run(nil); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	got, err := os.ReadFile(destAbs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hasConflictMarkers(got) {
+		t.Errorf("conflict markers not stripped:\n%s", got)
+	}
+	if !strings.Contains(string(got), "ther") {
+		t.Errorf("upstream side missing:\n%s", got)
+	}
+
+	lk2, err := lock.ReadLock(tmp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if lk2.Envs[0].Files[0].SHA256 == "stale-sha" {
+		t.Errorf("lock SHA was not updated")
+	}
+}
+
+// TestEnvResolveRun_PathTraversalRejected verifies that a malicious
+// lock entry pointing outside the project root is rejected before
+// any file I/O happens.
+func TestEnvResolveRun_PathTraversalRejected(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("PATH_BASE", tmp)
+	lk := &lock.Lock{
+		Version: 1,
+		Envs: []lock.EnvEntry{{
+			Ref: "github.com/org/infra",
+			Files: []lock.LockFile{
+				{Path: "evil", Dest: "../../etc/passwd", SHA256: "x"},
+			},
+		}},
+	}
+	if err := lock.WriteLock(tmp, lk, "test"); err != nil {
+		t.Fatal(err)
+	}
+
+	var out bytes.Buffer
+	o := &EnvResolveOptions{
+		SharedOptions: &SharedOptions{
+			IO:               &streams.IO{Out: &out, ErrOut: &bytes.Buffer{}},
+			loadedConfigPath: filepath.Join(tmp, "b.yaml"),
+		},
+	}
+	err := o.Run(nil)
+	if err == nil {
+		t.Fatal("expected path-traversal error")
+	}
+	if !strings.Contains(err.Error(), "path traversal") {
+		t.Errorf("error should mention path traversal, got: %v", err)
 	}
 }
 

--- a/pkg/cli/env_resolve_test.go
+++ b/pkg/cli/env_resolve_test.go
@@ -1,0 +1,122 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestResolveConflictMarkers_Diff3KeepOurs handles the diff3-format
+// markers that `git merge-file --diff3` (and therefore b's merge
+// path) writes today.
+func TestResolveConflictMarkers_Diff3KeepOurs(t *testing.T) {
+	in := []byte(`before
+<<<<<<< local
+ours-line
+||||||| base
+base-line
+=======
+theirs-line
+>>>>>>> upstream
+after
+`)
+	out, n, err := resolveConflictMarkers(in, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 1 {
+		t.Errorf("want 1 region, got %d", n)
+	}
+	s := string(out)
+	if !strings.Contains(s, "ours-line") {
+		t.Errorf("ours line missing: %s", s)
+	}
+	if strings.Contains(s, "theirs-line") || strings.Contains(s, "base-line") {
+		t.Errorf("non-ours content survived: %s", s)
+	}
+	if strings.Contains(s, "<<<<<<<") || strings.Contains(s, ">>>>>>>") {
+		t.Errorf("markers survived: %s", s)
+	}
+}
+
+func TestResolveConflictMarkers_Diff3KeepTheirs(t *testing.T) {
+	in := []byte("a\n<<<<<<< local\nours\n||||||| base\nbase\n=======\ntheirs\n>>>>>>> upstream\nz\n")
+	out, n, err := resolveConflictMarkers(in, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 1 {
+		t.Errorf("want 1, got %d", n)
+	}
+	s := string(out)
+	if !strings.Contains(s, "theirs") || strings.Contains(s, "ours") || strings.Contains(s, "base") {
+		t.Errorf("wrong content kept: %s", s)
+	}
+}
+
+// TestResolveConflictMarkers_TwoWayForm — bare 2-way markers without
+// the `|||||||` base section. Hand-edited files often look like this,
+// and the parser must accept them.
+func TestResolveConflictMarkers_TwoWayForm(t *testing.T) {
+	in := []byte("<<<<<<< local\nours\n=======\ntheirs\n>>>>>>> upstream\n")
+	out, n, err := resolveConflictMarkers(in, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 1 {
+		t.Errorf("want 1, got %d", n)
+	}
+	if !strings.Contains(string(out), "ours") {
+		t.Errorf("ours missing: %s", out)
+	}
+}
+
+// TestResolveConflictMarkers_MultipleRegions resolves several regions
+// in one pass.
+func TestResolveConflictMarkers_MultipleRegions(t *testing.T) {
+	in := []byte(`a
+<<<<<<< local
+ours1
+=======
+theirs1
+>>>>>>> upstream
+b
+<<<<<<< local
+ours2
+=======
+theirs2
+>>>>>>> upstream
+c
+`)
+	out, n, err := resolveConflictMarkers(in, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 2 {
+		t.Errorf("want 2 regions, got %d", n)
+	}
+	s := string(out)
+	if !strings.Contains(s, "theirs1") || !strings.Contains(s, "theirs2") {
+		t.Errorf("missing theirs content: %s", s)
+	}
+}
+
+// TestResolveConflictMarkers_Unterminated returns an error rather
+// than producing garbage when the closing marker is missing.
+func TestResolveConflictMarkers_Unterminated(t *testing.T) {
+	in := []byte("<<<<<<< local\nstuff\n=======\nmore\n")
+	_, _, err := resolveConflictMarkers(in, true)
+	if err == nil {
+		t.Error("expected error for unterminated region")
+	}
+}
+
+// TestHasConflictMarkers requires all three signature pieces so a
+// markdown rule like `=======` alone doesn't trip the detector.
+func TestHasConflictMarkers(t *testing.T) {
+	if hasConflictMarkers([]byte("=======\n")) {
+		t.Error("=======-only should not be a conflict")
+	}
+	if !hasConflictMarkers([]byte("<<<<<<< local\nx\n=======\ny\n>>>>>>> upstream\n")) {
+		t.Error("full conflict not detected")
+	}
+}

--- a/pkg/cli/env_resolve_test.go
+++ b/pkg/cli/env_resolve_test.go
@@ -238,4 +238,10 @@ func TestHasConflictMarkers(t *testing.T) {
 	if hasConflictMarkers([]byte(">>>>>>> stray\n")) {
 		t.Error("stray closing marker should not be a conflict")
 	}
+	// Bare markers without a label suffix (hand-edited form)
+	// MUST be detected — resolveConflictMarkers uses the same
+	// loose prefix and will happily rewrite them.
+	if !hasConflictMarkers([]byte("<<<<<<<\nx\n=======\ny\n>>>>>>>\n")) {
+		t.Error("bare-marker conflict (no label suffix) should be detected")
+	}
 }

--- a/pkg/cli/more_coverage_test.go
+++ b/pkg/cli/more_coverage_test.go
@@ -587,7 +587,7 @@ func TestInstallOptions_RunEnvInstalls_Local(t *testing.T) {
 
 func TestNewEnvCmd_Subcommands(t *testing.T) {
 	c := NewEnvCmd(NewSharedOptions(mkIO(), nil))
-	for _, sub := range []string{"status", "remove", "match", "profiles", "add"} {
+	for _, sub := range []string{"status", "remove", "match", "profiles", "add", "resolve"} {
 		c.SetArgs([]string{sub, "--help"})
 		if err := c.Execute(); err != nil {
 			t.Errorf("Execute: %v", err)


### PR DESCRIPTION
## Summary
- New \`b env resolve\` subcommand finds and bulk-resolves git-style merge conflict markers in synced env files
- \`--ours\` keeps the local block, \`--theirs\` keeps the upstream block, no flag = list-only
- Optional positional args restrict scope to specific env keys
- Parser handles both diff3 form (which b writes) and bare 2-way form (for hand-edited files)
- Returns errors on unterminated regions instead of producing garbage

## Why
Phase 4 of issue #125 adds the resolution path: today, conflicts left by \`b env update\` are silently committed to the consumer's tree as raw \`<<<<<<<\` markers and the user has no \`b\`-native way to resolve them in bulk.

## Out of scope (deliberate follow-up)
Phase 4 also covers writing in-place YAML comment markers (\`# b: CONFLICT upstream=v1.31 base=v1.30 local=v1.32\`) on the producer side. That conversion is its own PR — this command speaks the marker format that's actually written today, so it works on conflict regions left by current \`b env update\` runs.

## Examples
\`\`\`
$ b env resolve
  github.com/org/infra → .bin/b.yaml

1 conflicted file(s). Re-run with --ours or --theirs to resolve in bulk, or edit them manually.

$ b env resolve --theirs github.com/org/infra
  github.com/org/infra → .bin/b.yaml
    → resolved 2 region(s) in favor of upstream

Resolved 2 region(s) across 1 file(s).
\`\`\`

## Test plan
- [x] \`go test ./pkg/cli/... -run Resolve\`
- [x] full \`go test ./...\`
- [x] \`golangci-lint run ./pkg/cli/...\`

Refs #125

🤖 Generated with [Claude Code](https://claude.com/claude-code)