### PR TITLE
feat(cli): surface conflict markers in env status

### DIFF
--- a/pkg/cli/env.go
+++ b/pkg/cli/env.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"bufio"
+	"bytes"
 	"errors"
 	"fmt"
 	"io"
@@ -22,6 +23,16 @@ import (
 	"github.com/fentas/b/pkg/path"
 	"github.com/fentas/b/pkg/state"
 )
+
+// hasConflictMarkers reports whether the byte slice contains all
+// three pieces of a git merge-file conflict region. We require all
+// three so partial matches (e.g. a markdown rule line that contains
+// `=======`) don't trip the detector.
+func hasConflictMarkers(b []byte) bool {
+	return bytes.Contains(b, []byte("<<<<<<<")) &&
+		bytes.Contains(b, []byte("=======")) &&
+		bytes.Contains(b, []byte(">>>>>>>"))
+}
 
 // NewEnvCmd creates the env parent command with subcommands.
 func NewEnvCmd(shared *SharedOptions) *cobra.Command {
@@ -108,6 +119,12 @@ func (o *EnvStatusOptions) Run() error {
 		// Check local files for drift (content and mode)
 		localDrift := 0
 		missingFiles := 0
+		// Conflicted files are surfaced separately so users see them
+		// in `b env status` without having to run `b env resolve`.
+		// They still count as drift internally — a file with markers
+		// is by definition modified relative to the lock — but we
+		// also report the conflict count so the message is actionable.
+		conflictedFiles := 0
 		for _, f := range lockEntry.Files {
 			destPath := f.Dest
 			if !filepath.IsAbs(destPath) {
@@ -137,6 +154,14 @@ func (o *EnvStatusOptions) Run() error {
 			}
 			if hash != f.SHA256 {
 				localDrift++
+				// Re-read and check for conflict markers so the
+				// status output can call them out specifically. We
+				// only ever read files we already know are drifted,
+				// so this is bounded by `localDrift` rather than
+				// scanning every synced file on every status run.
+				if data, rerr := os.ReadFile(destPath); rerr == nil && hasConflictMarkers(data) {
+					conflictedFiles++
+				}
 				continue
 			}
 			// Also check file mode drift when lock records a mode
@@ -163,6 +188,9 @@ func (o *EnvStatusOptions) Run() error {
 			}
 			if localDrift > 0 {
 				fmt.Fprintf(o.IO.Out, "    ✎ %d file(s) modified locally\n", localDrift)
+			}
+			if conflictedFiles > 0 {
+				fmt.Fprintf(o.IO.Out, "    ✗ %d file(s) with unresolved conflict markers — run `b env resolve`\n", conflictedFiles)
 			}
 			if missingFiles > 0 {
 				fmt.Fprintf(o.IO.Out, "    ✗ %d file(s) missing\n", missingFiles)

--- a/pkg/cli/env.go
+++ b/pkg/cli/env.go
@@ -25,11 +25,83 @@ import (
 	"github.com/fentas/b/pkg/state"
 )
 
+// conflictMarkerScanner is a small line-anchored detector for git
+// merge-file conflict regions. It is line-oriented so a markdown
+// rule like `=======` or a stray `<<<<<<<` inside a string literal
+// can't trip the detector. CRLF endings are tolerated by trimming
+// `\r` off the end of each candidate line before comparison.
+//
+// The scanner is intentionally state-machine based instead of using
+// bufio.Scanner so a single very long line cannot exceed the buffer
+// limit and panic / fall back silently — `b env status` is expected
+// to scan arbitrary user files including SOPS-encrypted blobs.
+type conflictMarkerScanner struct {
+	hasStart, hasSep, hasEnd bool
+	// pending holds the bytes of the current line so far. We only
+	// keep up to the first 64 bytes — the markers we care about are
+	// all <= 16 bytes — so a degenerate one-line file with no
+	// newlines doesn't grow this slice unbounded.
+	pending []byte
+}
+
+const conflictPendingMax = 64
+
+// Update feeds another chunk of file bytes to the scanner. Returns
+// true once all three marker shapes have been seen (the caller can
+// stop checking after that).
+func (s *conflictMarkerScanner) Update(chunk []byte) bool {
+	if s.allSeen() {
+		return true
+	}
+	for _, b := range chunk {
+		if b == '\n' {
+			s.consumeLine()
+			s.pending = s.pending[:0]
+			if s.allSeen() {
+				return true
+			}
+			continue
+		}
+		if len(s.pending) < conflictPendingMax {
+			s.pending = append(s.pending, b)
+		}
+	}
+	return s.allSeen()
+}
+
+// Done flushes the final partial line (a file with no trailing
+// newline) and returns whether all three markers were seen.
+func (s *conflictMarkerScanner) Done() bool {
+	if !s.allSeen() {
+		s.consumeLine()
+	}
+	return s.allSeen()
+}
+
+func (s *conflictMarkerScanner) consumeLine() {
+	line := s.pending
+	// Tolerate CRLF: drop a trailing \r so the separator check
+	// matches `=======\r` files too.
+	if n := len(line); n > 0 && line[n-1] == '\r' {
+		line = line[:n-1]
+	}
+	switch {
+	case bytes.HasPrefix(line, []byte("<<<<<<< ")):
+		s.hasStart = true
+	case bytes.Equal(line, []byte("=======")):
+		s.hasSep = true
+	case bytes.HasPrefix(line, []byte(">>>>>>> ")):
+		s.hasEnd = true
+	}
+}
+
+func (s *conflictMarkerScanner) allSeen() bool {
+	return s.hasStart && s.hasSep && s.hasEnd
+}
+
 // hasConflictMarkers reports whether the byte slice contains a git
-// merge-file conflict region. The check is line-anchored so a
-// markdown rule line like `=======` or stray `<<<<<<<` inside a
-// string literal can't trip the detector. We early-return as soon
-// as all three line markers have been seen.
+// merge-file conflict region. The check is line-anchored, tolerates
+// CRLF endings, and has no maximum line length.
 //
 // Note: pkg/env/splice.go has a similar `containsConflictMarkers`
 // helper that uses substring matching and isn't currently exported.
@@ -37,24 +109,11 @@ import (
 // surface in this small follow-up; merging that into one shared
 // helper is tracked as a separate cleanup.
 func hasConflictMarkers(b []byte) bool {
-	var hasStart, hasSep, hasEnd bool
-	scanner := bufio.NewScanner(bytes.NewReader(b))
-	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
-	for scanner.Scan() {
-		line := scanner.Bytes()
-		switch {
-		case bytes.HasPrefix(line, []byte("<<<<<<< ")):
-			hasStart = true
-		case bytes.Equal(line, []byte("=======")):
-			hasSep = true
-		case bytes.HasPrefix(line, []byte(">>>>>>> ")):
-			hasEnd = true
-		}
-		if hasStart && hasSep && hasEnd {
-			return true
-		}
+	var s conflictMarkerScanner
+	if s.Update(b) {
+		return true
 	}
-	return false
+	return s.Done()
 }
 
 // hashAndScanConflicts reads a file once, computing its SHA-256 hex
@@ -67,6 +126,14 @@ func hasConflictMarkers(b []byte) bool {
 // error from the caller's perspective and is not handled specially
 // here — env.Status's existing missing-file branch checks os.Stat
 // before calling this helper.
+//
+// Implementation note: we deliberately don't use bufio.Scanner. Its
+// MaxScanTokenSize cap (default 64 KiB, configurable up to whatever
+// we set) would silently fall back on files with very long lines —
+// SOPS blobs, minified JSON, lockfiles. The conflictMarkerScanner
+// state machine has no per-line memory limit; a degenerate single
+// long line bounds at conflictPendingMax bytes regardless of file
+// size.
 func hashAndScanConflicts(path string) (string, bool, error) {
 	f, err := os.Open(path)
 	if err != nil {
@@ -75,29 +142,23 @@ func hashAndScanConflicts(path string) (string, bool, error) {
 	defer f.Close()
 
 	h := sha256.New()
-	scanner := bufio.NewScanner(io.TeeReader(f, h))
-	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
-	var hasStart, hasSep, hasEnd, hasAll bool
-	for scanner.Scan() {
-		line := scanner.Bytes()
-		if !hasAll {
-			switch {
-			case bytes.HasPrefix(line, []byte("<<<<<<< ")):
-				hasStart = true
-			case bytes.Equal(line, []byte("=======")):
-				hasSep = true
-			case bytes.HasPrefix(line, []byte(">>>>>>> ")):
-				hasEnd = true
-			}
-			if hasStart && hasSep && hasEnd {
-				hasAll = true
-			}
+	var ms conflictMarkerScanner
+	buf := make([]byte, 64*1024)
+	for {
+		n, rerr := f.Read(buf)
+		if n > 0 {
+			h.Write(buf[:n])
+			ms.Update(buf[:n])
+		}
+		if rerr == io.EOF {
+			break
+		}
+		if rerr != nil {
+			return "", false, rerr
 		}
 	}
-	if err := scanner.Err(); err != nil {
-		return "", false, err
-	}
-	return fmt.Sprintf("%x", h.Sum(nil)), hasAll, nil
+	hasMarkers := ms.Done()
+	return fmt.Sprintf("%x", h.Sum(nil)), hasMarkers, nil
 }
 
 // NewEnvCmd creates the env parent command with subcommands.
@@ -185,11 +246,15 @@ func (o *EnvStatusOptions) Run() error {
 		// Check local files for drift (content and mode)
 		localDrift := 0
 		missingFiles := 0
-		// Conflicted files are surfaced separately so users see them
-		// in `b env status` without having to run `b env resolve`.
-		// They still count as drift internally — a file with markers
-		// is by definition modified relative to the lock — but we
-		// also report the conflict count so the message is actionable.
+		// Conflicted files are surfaced as a distinct counter so
+		// users see them in `b env status` without having to run
+		// `b env resolve`. We deliberately do NOT also count them
+		// as drift: when env update writes a merge result with
+		// conflict markers, the lock SHA records the post-merge
+		// bytes (markers and all), so a conflicted file may match
+		// its lock SHA exactly. Treating it as drift would mask
+		// the more actionable "unresolved conflict markers"
+		// message; the conflict counter is the source of truth.
 		conflictedFiles := 0
 		for _, f := range lockEntry.Files {
 			destPath := f.Dest

--- a/pkg/cli/env.go
+++ b/pkg/cli/env.go
@@ -32,9 +32,12 @@ import (
 // `\r` off the end of each candidate line before comparison.
 //
 // The scanner is intentionally state-machine based instead of using
-// bufio.Scanner so a single very long line cannot exceed the buffer
-// limit and panic / fall back silently — `b env status` is expected
-// to scan arbitrary user files including SOPS-encrypted blobs.
+// bufio.Scanner. Scanner.Scan() returns false with bufio.ErrTooLong
+// when a single line exceeds its buffer cap, and unless the caller
+// also checks scanner.Err() the result silently looks like
+// "no markers". `b env status` is expected to scan arbitrary user
+// files including SOPS-encrypted blobs and minified JSON, so we
+// avoid the per-line cap entirely.
 type conflictMarkerScanner struct {
 	hasStart, hasSep, hasEnd bool
 	// pending holds the bytes of the current line so far. We only
@@ -127,13 +130,14 @@ func hasConflictMarkers(b []byte) bool {
 // here — env.Status's existing missing-file branch checks os.Stat
 // before calling this helper.
 //
-// Implementation note: we deliberately don't use bufio.Scanner. Its
-// MaxScanTokenSize cap (default 64 KiB, configurable up to whatever
-// we set) would silently fall back on files with very long lines —
-// SOPS blobs, minified JSON, lockfiles. The conflictMarkerScanner
-// state machine has no per-line memory limit; a degenerate single
+// Implementation note: we deliberately don't use bufio.Scanner.
+// Scanner.Scan() returns false with bufio.ErrTooLong when a line
+// exceeds its buffer cap; if the caller forgets scanner.Err() the
+// result silently looks like "no markers". The conflictMarkerScanner
+// state machine has no per-line memory limit — a degenerate single
 // long line bounds at conflictPendingMax bytes regardless of file
-// size.
+// size — so SOPS blobs, minified JSON, and lockfiles all scan
+// correctly.
 func hashAndScanConflicts(path string) (string, bool, error) {
 	f, err := os.Open(path)
 	if err != nil {

--- a/pkg/cli/env.go
+++ b/pkg/cli/env.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"bufio"
 	"bytes"
+	"crypto/sha256"
 	"errors"
 	"fmt"
 	"io"
@@ -24,14 +25,79 @@ import (
 	"github.com/fentas/b/pkg/state"
 )
 
-// hasConflictMarkers reports whether the byte slice contains all
-// three pieces of a git merge-file conflict region. We require all
-// three so partial matches (e.g. a markdown rule line that contains
-// `=======`) don't trip the detector.
+// hasConflictMarkers reports whether the byte slice contains a git
+// merge-file conflict region. The check is line-anchored so a
+// markdown rule line like `=======` or stray `<<<<<<<` inside a
+// string literal can't trip the detector. We early-return as soon
+// as all three line markers have been seen.
+//
+// Note: pkg/env/splice.go has a similar `containsConflictMarkers`
+// helper that uses substring matching and isn't currently exported.
+// Keeping a local copy here to avoid widening the pkg/env API
+// surface in this small follow-up; merging that into one shared
+// helper is tracked as a separate cleanup.
 func hasConflictMarkers(b []byte) bool {
-	return bytes.Contains(b, []byte("<<<<<<<")) &&
-		bytes.Contains(b, []byte("=======")) &&
-		bytes.Contains(b, []byte(">>>>>>>"))
+	var hasStart, hasSep, hasEnd bool
+	scanner := bufio.NewScanner(bytes.NewReader(b))
+	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		switch {
+		case bytes.HasPrefix(line, []byte("<<<<<<< ")):
+			hasStart = true
+		case bytes.Equal(line, []byte("=======")):
+			hasSep = true
+		case bytes.HasPrefix(line, []byte(">>>>>>> ")):
+			hasEnd = true
+		}
+		if hasStart && hasSep && hasEnd {
+			return true
+		}
+	}
+	return false
+}
+
+// hashAndScanConflicts reads a file once, computing its SHA-256 hex
+// digest and detecting whether the contents include any git
+// merge-file conflict region. Bundling the two passes lets `b env
+// status` scan every synced file without paying for two reads (one
+// for the hash, one for the marker check).
+//
+// Returns ("", false, err) on read failure. A missing file is an
+// error from the caller's perspective and is not handled specially
+// here — env.Status's existing missing-file branch checks os.Stat
+// before calling this helper.
+func hashAndScanConflicts(path string) (string, bool, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", false, err
+	}
+	defer f.Close()
+
+	h := sha256.New()
+	scanner := bufio.NewScanner(io.TeeReader(f, h))
+	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
+	var hasStart, hasSep, hasEnd, hasAll bool
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if !hasAll {
+			switch {
+			case bytes.HasPrefix(line, []byte("<<<<<<< ")):
+				hasStart = true
+			case bytes.Equal(line, []byte("=======")):
+				hasSep = true
+			case bytes.HasPrefix(line, []byte(">>>>>>> ")):
+				hasEnd = true
+			}
+			if hasStart && hasSep && hasEnd {
+				hasAll = true
+			}
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return "", false, err
+	}
+	return fmt.Sprintf("%x", h.Sum(nil)), hasAll, nil
 }
 
 // NewEnvCmd creates the env parent command with subcommands.
@@ -147,21 +213,23 @@ func (o *EnvStatusOptions) Run() error {
 				}
 				continue
 			}
-			hash, err := lock.SHA256File(destPath)
+			// Single-pass: hash the file AND scan it for conflict
+			// markers in one read. We must scan EVERY synced file,
+			// not just ones whose SHA drifted, because env update
+			// records the post-merge bytes (including any conflict
+			// markers) into the lock — so a conflicted file can
+			// match its lock SHA exactly and would otherwise be
+			// reported as "✓ up to date".
+			hash, hasMarkers, err := hashAndScanConflicts(destPath)
 			if err != nil {
 				localDrift++
 				continue
 			}
+			if hasMarkers {
+				conflictedFiles++
+			}
 			if hash != f.SHA256 {
 				localDrift++
-				// Re-read and check for conflict markers so the
-				// status output can call them out specifically. We
-				// only ever read files we already know are drifted,
-				// so this is bounded by `localDrift` rather than
-				// scanning every synced file on every status run.
-				if data, rerr := os.ReadFile(destPath); rerr == nil && hasConflictMarkers(data) {
-					conflictedFiles++
-				}
 				continue
 			}
 			// Also check file mode drift when lock records a mode
@@ -178,8 +246,10 @@ func (o *EnvStatusOptions) Run() error {
 			}
 		}
 
-		// Build status line
-		if upstreamStatus == "" && localDrift == 0 && missingFiles == 0 {
+		// Build status line. Conflicted files block the "up to date"
+		// shortcut even when their on-disk SHA matches the lock —
+		// the user still needs to resolve the markers.
+		if upstreamStatus == "" && localDrift == 0 && missingFiles == 0 && conflictedFiles == 0 {
 			fmt.Fprintf(o.IO.Out, "  %-40s %s @ %s ✓ up to date\n", entry.Key, version, shortCommit(lockEntry.Commit))
 		} else {
 			fmt.Fprintf(o.IO.Out, "  %-40s %s @ %s\n", entry.Key, version, shortCommit(lockEntry.Commit))

--- a/pkg/cli/env.go
+++ b/pkg/cli/env.go
@@ -291,7 +291,15 @@ func (o *EnvStatusOptions) Run() error {
 				continue
 			}
 			if hasMarkers {
+				// Count conflicted files separately so users get
+				// the actionable "run b env resolve" message
+				// instead of the generic drift number. A
+				// conflicted file is NOT also counted as drift,
+				// even when its SHA happens to differ from the
+				// lock — the conflict counter is the source of
+				// truth.
 				conflictedFiles++
+				continue
 			}
 			if hash != f.SHA256 {
 				localDrift++

--- a/pkg/cli/env.go
+++ b/pkg/cli/env.go
@@ -89,14 +89,23 @@ func (s *conflictMarkerScanner) consumeLine() {
 		line = line[:n-1]
 	}
 	switch {
-	case bytes.HasPrefix(line, []byte("<<<<<<< ")):
+	case bytes.HasPrefix(line, conflictStartMarker):
 		s.hasStart = true
-	case bytes.Equal(line, []byte("=======")):
+	case bytes.Equal(line, conflictSepMarker):
 		s.hasSep = true
-	case bytes.HasPrefix(line, []byte(">>>>>>> ")):
+	case bytes.HasPrefix(line, conflictEndMarker):
 		s.hasEnd = true
 	}
 }
+
+// Package-level marker byte slices. Defined once so the
+// per-line consumeLine path doesn't allocate a fresh []byte on
+// every comparison while scanning large files.
+var (
+	conflictStartMarker = []byte("<<<<<<< ")
+	conflictSepMarker   = []byte("=======")
+	conflictEndMarker   = []byte(">>>>>>> ")
+)
 
 func (s *conflictMarkerScanner) allSeen() bool {
 	return s.hasStart && s.hasSep && s.hasEnd

--- a/pkg/cli/env_status_conflict_test.go
+++ b/pkg/cli/env_status_conflict_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -26,6 +27,16 @@ func TestHasConflictMarkers_StatusHelper(t *testing.T) {
 		{"stray opener inside string", `value: "<<<<<<<"` + "\n", false},
 		{"full diff3", "<<<<<<< local\nours\n||||||| base\nbase\n=======\ntheirs\n>>>>>>> upstream\n", true},
 		{"full 2-way", "<<<<<<< local\nours\n=======\ntheirs\n>>>>>>> upstream\n", true},
+		// CRLF endings: the separator line is `=======\r` after
+		// scanning, which a naive bytes.Equal would miss. The
+		// scanner trims the trailing \r before comparing.
+		{"full 2-way CRLF", "<<<<<<< local\r\nours\r\n=======\r\ntheirs\r\n>>>>>>> upstream\r\n", true},
+		// Very long line with no newline must not panic or fall
+		// back. Build a 200KB line of `x` followed by a real
+		// conflict region; the scanner state machine should ignore
+		// the long line entirely (no marker prefix matches) and
+		// still detect the conflict that comes after.
+		{"long line then conflict", strings.Repeat("x", 200*1024) + "\n<<<<<<< local\nours\n=======\ntheirs\n>>>>>>> upstream\n", true},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {

--- a/pkg/cli/env_status_conflict_test.go
+++ b/pkg/cli/env_status_conflict_test.go
@@ -1,10 +1,17 @@
 package cli
 
-import "testing"
+import (
+	"crypto/sha256"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
 
-// TestHasConflictMarkers covers the local helper used by env status to
-// flag conflicted files. We need all three of <<<<<<< / ======= /
-// >>>>>>> for a positive match so partial markdown rules don't trigger.
+// TestHasConflictMarkers covers the local helper used by env status
+// to flag conflicted files. The check is line-anchored so a markdown
+// rule (`=======`) or stray `<<<<<<<` inside a string literal does
+// not trigger a false positive.
 func TestHasConflictMarkers_StatusHelper(t *testing.T) {
 	cases := []struct {
 		name string
@@ -15,6 +22,8 @@ func TestHasConflictMarkers_StatusHelper(t *testing.T) {
 		{"plain text", "hello world\n", false},
 		{"only equals", "=======\n", false},
 		{"only opener", "<<<<<<< local\nstuff\n", false},
+		{"markdown rule", "title\n=======\nbody\n", false},
+		{"stray opener inside string", `value: "<<<<<<<"` + "\n", false},
 		{"full diff3", "<<<<<<< local\nours\n||||||| base\nbase\n=======\ntheirs\n>>>>>>> upstream\n", true},
 		{"full 2-way", "<<<<<<< local\nours\n=======\ntheirs\n>>>>>>> upstream\n", true},
 	}
@@ -22,6 +31,44 @@ func TestHasConflictMarkers_StatusHelper(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			if got := hasConflictMarkers([]byte(c.in)); got != c.want {
 				t.Errorf("hasConflictMarkers(%q) = %v, want %v", c.in, got, c.want)
+			}
+		})
+	}
+}
+
+// TestHashAndScanConflicts verifies the bundled streaming helper
+// produces the same hex digest as crypto/sha256 over the same bytes
+// AND correctly detects markers in a single read pass.
+func TestHashAndScanConflicts(t *testing.T) {
+	tmp := t.TempDir()
+	cases := []struct {
+		name        string
+		body        string
+		wantMarkers bool
+	}{
+		{"clean", "hello\nworld\n", false},
+		{
+			"conflicted",
+			"line1\n<<<<<<< local\nours\n=======\ntheirs\n>>>>>>> upstream\nline7\n",
+			true,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			path := filepath.Join(tmp, c.name+".txt")
+			if err := os.WriteFile(path, []byte(c.body), 0644); err != nil {
+				t.Fatal(err)
+			}
+			gotHash, gotMarkers, err := hashAndScanConflicts(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			wantHash := fmt.Sprintf("%x", sha256.Sum256([]byte(c.body)))
+			if gotHash != wantHash {
+				t.Errorf("hash = %s, want %s", gotHash, wantHash)
+			}
+			if gotMarkers != c.wantMarkers {
+				t.Errorf("markers = %v, want %v", gotMarkers, c.wantMarkers)
 			}
 		})
 	}

--- a/pkg/cli/env_status_conflict_test.go
+++ b/pkg/cli/env_status_conflict_test.go
@@ -1,0 +1,28 @@
+package cli
+
+import "testing"
+
+// TestHasConflictMarkers covers the local helper used by env status to
+// flag conflicted files. We need all three of <<<<<<< / ======= /
+// >>>>>>> for a positive match so partial markdown rules don't trigger.
+func TestHasConflictMarkers_StatusHelper(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want bool
+	}{
+		{"empty", "", false},
+		{"plain text", "hello world\n", false},
+		{"only equals", "=======\n", false},
+		{"only opener", "<<<<<<< local\nstuff\n", false},
+		{"full diff3", "<<<<<<< local\nours\n||||||| base\nbase\n=======\ntheirs\n>>>>>>> upstream\n", true},
+		{"full 2-way", "<<<<<<< local\nours\n=======\ntheirs\n>>>>>>> upstream\n", true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := hasConflictMarkers([]byte(c.in)); got != c.want {
+				t.Errorf("hasConflictMarkers(%q) = %v, want %v", c.in, got, c.want)
+			}
+		})
+	}
+}

--- a/pkg/cli/env_status_conflict_test.go
+++ b/pkg/cli/env_status_conflict_test.go
@@ -9,10 +9,12 @@ import (
 	"testing"
 )
 
-// TestHasConflictMarkers covers the local helper used by env status
-// to flag conflicted files. The check is line-anchored so a markdown
-// rule (`=======`) or stray `<<<<<<<` inside a string literal does
-// not trigger a false positive.
+// TestHasConflictMarkers exercises the standalone byte-slice
+// detector. env status itself uses hashAndScanConflicts (which
+// streams the file once and shares the same scanner state machine);
+// this test covers the underlying classification logic with the
+// same edge cases. Line-anchored so a markdown rule (`=======`) or
+// stray `<<<<<<<` inside a string literal can't false-positive.
 func TestHasConflictMarkers_StatusHelper(t *testing.T) {
 	cases := []struct {
 		name string
@@ -41,7 +43,10 @@ func TestHasConflictMarkers_StatusHelper(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			if got := hasConflictMarkers([]byte(c.in)); got != c.want {
-				t.Errorf("hasConflictMarkers(%q) = %v, want %v", c.in, got, c.want)
+				// Print the case name (not the input) so the
+				// 200 KiB long-line case doesn't dump itself
+				// into the failure log.
+				t.Errorf("hasConflictMarkers case %q = %v, want %v", c.name, got, c.want)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
- \`b env status\` now reports files containing git-style merge conflict markers as a distinct category
- New line: \`✗ N file(s) with unresolved conflict markers — run \\\`b env resolve\\\`\`
- Scan is runs on every synced file (the previous "drift-bounded" wording was wrong: a conflicted file can match its lock SHA exactly so we have to scan unconditionally), so cost is proportional to actual problems

## Why
Today, an unresolved conflict left by \`b env update\` is silently rolled into the generic \"modified locally\" counter, so consumers have no in-CLI signal that something needs human attention. This is the natural status-side complement to \`b env resolve\` (#138) and the broader #125 transparency push.

## Note on overlap
\`hasConflictMarkers\` is intentionally inlined here. PR #138 (\`b env resolve\`) defines the same helper. When both merge, one side will need a trivial rebase to dedupe the function — flagging here so it's not a surprise.

## Test plan
- [x] \`go test ./pkg/cli/... -run HasConflictMarkers_StatusHelper\`
- [x] full \`go test ./...\`
- [x] \`golangci-lint run ./pkg/cli/...\`

Refs #125 #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)
