### PR TITLE
fix(provider): surface portable scripts, filter libs; persist interactive pick

### DIFF
--- a/pkg/cli/resolve_test.go
+++ b/pkg/cli/resolve_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"fmt"
+	"os"
 	"runtime"
 	"strings"
 	"testing"
@@ -259,6 +260,103 @@ func TestResolveAmbiguousAssets_TiedScore_QuietPicksFirst(t *testing.T) {
 	wantPrefix := fmt.Sprintf("tool-%s-%s", runtime.GOOS, runtime.GOARCH)
 	if !strings.HasPrefix(b.ResolvedAsset.Name, wantPrefix) {
 		t.Errorf("ResolvedAsset.Name = %q, want prefix %q", b.ResolvedAsset.Name, wantPrefix)
+	}
+	// Quiet/non-TTY auto-picks must NOT persist — user never saw the choice.
+	if b.AssetFilter != "" {
+		t.Errorf("quiet auto-pick should not set AssetFilter, got %q", b.AssetFilter)
+	}
+}
+
+// fakeTrueTieProvider returns two assets that actually tie on score: both
+// have the same OS/arch, neither is an archive, neither contains the repo
+// name — both score 10.
+type fakeTrueTieProvider struct{}
+
+func (f *fakeTrueTieProvider) Name() string { return "faketruetie" }
+func (f *fakeTrueTieProvider) Match(ref string) bool {
+	return strings.HasPrefix(ref, "faketruetie://")
+}
+func (f *fakeTrueTieProvider) LatestVersion(ref string) (string, error) { return "v1.0.0", nil }
+func (f *fakeTrueTieProvider) FetchRelease(ref, version string) (*provider.Release, error) {
+	name1 := fmt.Sprintf("pick-me-%s-%s", runtime.GOOS, runtime.GOARCH)
+	name2 := fmt.Sprintf("or-me-%s-%s", runtime.GOOS, runtime.GOARCH)
+	return &provider.Release{
+		Version: version,
+		Assets: []provider.Asset{
+			{Name: name1, URL: "https://example.com/" + name1, Size: 1024},
+			{Name: name2, URL: "https://example.com/" + name2, Size: 2048},
+		},
+	}, nil
+}
+
+func init() {
+	provider.Register(&fakeTrueTieProvider{})
+}
+
+// TestResolveAmbiguousAssets_QuietAutoPick_DoesNotPersist ensures that a
+// quiet/non-TTY auto-pick of a genuinely tied ambiguity does NOT set
+// AssetFilter — the user never saw the choice so we won't pin it.
+func TestResolveAmbiguousAssets_QuietAutoPick_DoesNotPersist(t *testing.T) {
+	b := &binary.Binary{
+		Name:        "tool",
+		AutoDetect:  true,
+		ProviderRef: "faketruetie://org/unique",
+		Version:     "v1.0.0",
+	}
+	out := &streams.IO{Out: &discardWriter{}, ErrOut: &discardWriter{}}
+	resolveAmbiguousAssets([]*binary.Binary{b}, true, out) // quiet=true
+
+	if b.ResolvedAsset == nil {
+		t.Fatal("expected ResolvedAsset to be set (auto-pick)")
+	}
+	if b.AssetFilter != "" {
+		t.Errorf("quiet auto-pick of tied candidates must not persist, got %q", b.AssetFilter)
+	}
+}
+
+// TestResolveAmbiguousAssets_Interactive_PersistsChoice verifies that when
+// the interactive picker is actually used (TTY + not quiet + user picks),
+// the chosen asset name is stored on AssetFilter so 'b install --add' can
+// persist it to b.yaml and 'b update' keeps using the same asset.
+func TestResolveAmbiguousAssets_Interactive_PersistsChoice(t *testing.T) {
+	// Force the TTY check to true and stdin to a known choice.
+	origTTY := isTTYFunc
+	isTTYFunc = func() bool { return true }
+	defer func() { isTTYFunc = origTTY }()
+
+	origStdin := os.Stdin
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stdin = r
+	defer func() { os.Stdin = origStdin; r.Close() }()
+	// Pick choice "1" (first listed).
+	go func() {
+		fmt.Fprintln(w, "1")
+		w.Close()
+	}()
+
+	b := &binary.Binary{
+		// Name must not appear in assets so scoring doesn't award repo-name bonus
+		// asymmetrically.
+		Name:        "tool",
+		AutoDetect:  true,
+		ProviderRef: "faketruetie://org/unique",
+		Version:     "v1.0.0",
+	}
+	out := &streams.IO{Out: &discardWriter{}, ErrOut: &discardWriter{}}
+	// quiet=false → interactive prompt is used
+	resolveAmbiguousAssets([]*binary.Binary{b}, false, out)
+
+	if b.ResolvedAsset == nil {
+		t.Fatal("expected ResolvedAsset to be set after interactive pick")
+	}
+	if b.AssetFilter == "" {
+		t.Error("interactive pick should persist to AssetFilter for 'b install --add'")
+	}
+	if b.AssetFilter != b.ResolvedAsset.Name {
+		t.Errorf("AssetFilter = %q, want %q (same as picked asset)", b.AssetFilter, b.ResolvedAsset.Name)
 	}
 }
 

--- a/pkg/cli/resolve_test.go
+++ b/pkg/cli/resolve_test.go
@@ -364,6 +364,77 @@ func TestResolveAmbiguousAssets_Interactive_PersistsChoice(t *testing.T) {
 	}
 }
 
+// TestResolveAmbiguousAssets_Interactive_EOFDoesNotPersist verifies that
+// when the user closes stdin without picking (EOF), the default pick is
+// used for this run but NOT persisted to AssetFilter.
+func TestResolveAmbiguousAssets_Interactive_EOFDoesNotPersist(t *testing.T) {
+	origTTY := isTTYFunc
+	isTTYFunc = func() bool { return true }
+	defer func() { isTTYFunc = origTTY }()
+
+	origStdin := os.Stdin
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stdin = r
+	defer func() { os.Stdin = origStdin; r.Close() }()
+	w.Close() // EOF immediately — no input
+
+	b := &binary.Binary{
+		Name:        "tool",
+		AutoDetect:  true,
+		ProviderRef: "faketruetie://org/unique",
+		Version:     "v1.0.0",
+	}
+	out := &streams.IO{Out: &discardWriter{}, ErrOut: &discardWriter{}}
+	resolveAmbiguousAssets([]*binary.Binary{b}, false, out)
+
+	if b.ResolvedAsset == nil {
+		t.Fatal("expected ResolvedAsset to be set to default on EOF")
+	}
+	if b.AssetFilter != "" {
+		t.Errorf("EOF must not persist: AssetFilter = %q", b.AssetFilter)
+	}
+}
+
+// TestResolveAmbiguousAssets_Interactive_InvalidChoiceDoesNotPersist covers
+// the case where the user types a non-numeric or out-of-range value — the
+// default is used but not persisted.
+func TestResolveAmbiguousAssets_Interactive_InvalidChoiceDoesNotPersist(t *testing.T) {
+	origTTY := isTTYFunc
+	isTTYFunc = func() bool { return true }
+	defer func() { isTTYFunc = origTTY }()
+
+	origStdin := os.Stdin
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stdin = r
+	defer func() { os.Stdin = origStdin; r.Close() }()
+	go func() {
+		fmt.Fprintln(w, "nope")
+		w.Close()
+	}()
+
+	b := &binary.Binary{
+		Name:        "tool",
+		AutoDetect:  true,
+		ProviderRef: "faketruetie://org/unique",
+		Version:     "v1.0.0",
+	}
+	out := &streams.IO{Out: &discardWriter{}, ErrOut: &discardWriter{}}
+	resolveAmbiguousAssets([]*binary.Binary{b}, false, out)
+
+	if b.ResolvedAsset == nil {
+		t.Fatal("expected ResolvedAsset to be set to default on invalid input")
+	}
+	if b.AssetFilter != "" {
+		t.Errorf("invalid input must not persist: AssetFilter = %q", b.AssetFilter)
+	}
+}
+
 // TestEscapeAssetGlob verifies that glob metacharacters in asset filenames
 // are escaped so filepath.Match treats the persisted AssetFilter as a
 // literal name on subsequent runs.

--- a/pkg/cli/resolve_test.go
+++ b/pkg/cli/resolve_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
@@ -355,8 +356,41 @@ func TestResolveAmbiguousAssets_Interactive_PersistsChoice(t *testing.T) {
 	if b.AssetFilter == "" {
 		t.Error("interactive pick should persist to AssetFilter for 'b install --add'")
 	}
-	if b.AssetFilter != b.ResolvedAsset.Name {
-		t.Errorf("AssetFilter = %q, want %q (same as picked asset)", b.AssetFilter, b.ResolvedAsset.Name)
+	// AssetFilter may have glob metachars escaped; the correct invariant is
+	// that it matches the chosen asset's filename literally.
+	if m, err := filepath.Match(b.AssetFilter, b.ResolvedAsset.Name); err != nil || !m {
+		t.Errorf("AssetFilter=%q must match ResolvedAsset.Name=%q (matched=%v err=%v)",
+			b.AssetFilter, b.ResolvedAsset.Name, m, err)
+	}
+}
+
+// TestEscapeAssetGlob verifies that glob metacharacters in asset filenames
+// are escaped so filepath.Match treats the persisted AssetFilter as a
+// literal name on subsequent runs.
+func TestEscapeAssetGlob(t *testing.T) {
+	tests := []string{
+		"argsh",          // no metachars
+		"argsh-so-linux", // dashes fine
+		"foo*bar.tar.gz", // star
+		"what?.zip",      // question mark
+		"a[tag]b",        // brackets
+		"mix*of?[all]",   // mix
+	}
+	for _, in := range tests {
+		pattern := escapeAssetGlob(in)
+		matched, err := filepath.Match(pattern, in)
+		if err != nil {
+			t.Errorf("filepath.Match(%q, %q) error: %v", pattern, in, err)
+		}
+		if !matched {
+			t.Errorf("escaped pattern %q must match its original %q", pattern, in)
+		}
+		// And it must not match an altered name (sanity check).
+		if in != "x" {
+			if m, _ := filepath.Match(pattern, "x"+in); m {
+				t.Errorf("pattern %q unexpectedly matched %q", pattern, "x"+in)
+			}
+		}
 	}
 }
 

--- a/pkg/cli/shared.go
+++ b/pkg/cli/shared.go
@@ -380,21 +380,58 @@ func resolveAmbiguousAssets(binaries []*binary.Binary, quiet bool, io *streams.I
 		}
 
 		// Ambiguous — prompt user (or auto-pick in quiet/non-TTY mode).
-		// When a real TTY prompt is shown we persist the chosen asset name
-		// as AssetFilter so 'b update' keeps the same choice instead of
-		// re-prompting; quiet/non-TTY auto-picks are NOT persisted because
-		// the user never saw or consented to them.
-		interactive := !quiet && isTTYFunc()
+		// We persist the chosen asset name as AssetFilter only when the
+		// user explicitly picked it in the interactive prompt (so 'b update'
+		// keeps the same asset). Quiet/non-TTY auto-picks, EOF, and invalid
+		// input all fall through to a default without user consent and must
+		// NOT be persisted.
+		if !quiet && isTTYFunc() {
+			asset, confirmed := promptAssetPick(b, candidates, io)
+			b.ResolvedAsset = asset
+			if confirmed && b.AssetFilter == "" {
+				b.AssetFilter = escapeAssetGlob(asset.Name)
+			}
+			continue
+		}
+		// Non-interactive fallback — warn and pick the first tied candidate.
 		sel := defaultAssetSelector(b, quiet, io)
 		asset, err := sel(candidates)
 		if err != nil {
 			continue
 		}
 		b.ResolvedAsset = asset
-		if interactive && b.AssetFilter == "" {
-			b.AssetFilter = escapeAssetGlob(asset.Name)
+	}
+}
+
+// promptAssetPick displays the interactive picker and returns the chosen
+// asset along with a flag indicating whether the user made an explicit,
+// valid choice. EOF or invalid input returns the default (first) candidate
+// with confirmed=false so callers don't persist an unconfirmed pick.
+func promptAssetPick(bin *binary.Binary, candidates []provider.Scored, io *streams.IO) (*provider.Asset, bool) {
+	fmt.Fprintf(io.ErrOut, "\nMultiple assets match for %s. Select one:\n", color.New(color.Bold).Sprint(bin.Name))
+	topScore := candidates[0].Score
+	var choices []provider.Scored
+	for _, c := range candidates {
+		if c.Score == topScore {
+			choices = append(choices, c)
 		}
 	}
+	for i, c := range choices {
+		fmt.Fprintf(io.ErrOut, "  [%d] %s  (%s)\n", i+1, c.Asset.Name, formatSize(c.Asset.Size))
+	}
+	fmt.Fprintf(io.ErrOut, "Choice [1-%d]: ", len(choices))
+
+	var input string
+	if _, err := fmt.Fscanln(os.Stdin, &input); err != nil {
+		return choices[0].Asset, false // EOF / read error — not confirmed
+	}
+	input = strings.TrimSpace(input)
+	var idx int
+	if _, err := fmt.Sscanf(input, "%d", &idx); err != nil || idx < 1 || idx > len(choices) {
+		fmt.Fprintf(io.ErrOut, "Invalid choice, using %s\n", choices[0].Asset.Name)
+		return choices[0].Asset, false // invalid — not confirmed
+	}
+	return choices[idx-1].Asset, true
 }
 
 // escapeAssetGlob escapes glob metacharacters in an asset filename so that

--- a/pkg/cli/shared.go
+++ b/pkg/cli/shared.go
@@ -392,9 +392,25 @@ func resolveAmbiguousAssets(binaries []*binary.Binary, quiet bool, io *streams.I
 		}
 		b.ResolvedAsset = asset
 		if interactive && b.AssetFilter == "" {
-			b.AssetFilter = asset.Name
+			b.AssetFilter = escapeAssetGlob(asset.Name)
 		}
 	}
+}
+
+// escapeAssetGlob escapes glob metacharacters in an asset filename so that
+// later MatchAssets calls (which use filepath.Match) treat it as a literal
+// name. Without this, an asset whose filename contains '*', '?' or '['
+// could either fail to match or match unintended files on re-install.
+func escapeAssetGlob(name string) string {
+	// filepath.Match recognises '*', '?' and '[...]'. A bare '[' with no
+	// matching ']' makes the pattern invalid. Wrapping each metacharacter
+	// in its own class turns it into a literal.
+	r := strings.NewReplacer(
+		"*", "[*]",
+		"?", "[?]",
+		"[", "[[]",
+	)
+	return r.Replace(name)
 }
 
 // firstLine returns the first line of a string, trimming trailing CR/LF.

--- a/pkg/cli/shared.go
+++ b/pkg/cli/shared.go
@@ -379,13 +379,21 @@ func resolveAmbiguousAssets(binaries []*binary.Binary, quiet bool, io *streams.I
 			continue
 		}
 
-		// Ambiguous — prompt user (or auto-pick in quiet/non-TTY mode)
+		// Ambiguous — prompt user (or auto-pick in quiet/non-TTY mode).
+		// When a real TTY prompt is shown we persist the chosen asset name
+		// as AssetFilter so 'b update' keeps the same choice instead of
+		// re-prompting; quiet/non-TTY auto-picks are NOT persisted because
+		// the user never saw or consented to them.
+		interactive := !quiet && isTTYFunc()
 		sel := defaultAssetSelector(b, quiet, io)
 		asset, err := sel(candidates)
 		if err != nil {
 			continue
 		}
 		b.ResolvedAsset = asset
+		if interactive && b.AssetFilter == "" {
+			b.AssetFilter = asset.Name
+		}
 	}
 }
 

--- a/pkg/provider/detect.go
+++ b/pkg/provider/detect.go
@@ -21,13 +21,17 @@ var (
 		"386":   {"386", "i386", "i686", "x86", "32bit", "32-bit"},
 		"arm":   {"armv7", "armv6", "arm"},
 	}
-	// File extensions to filter out (not actual binaries).
+	// File extensions to filter out (not actual CLI binaries).
 	ignoreExtensions = []string{
 		".sha256", ".sha256sum", ".sha512", ".sha512sum",
 		".sig", ".asc", ".pem",
 		".txt", ".md", ".json",
 		".sbom", ".spdx",
 		".deb", ".rpm", ".msi", ".pkg", ".apk",
+		// Libraries / plugins / bundles — not executables.
+		".so", ".dylib", ".dll", ".a", ".lib",
+		".jar", ".aar",
+		".vsix", // VS Code extension bundle
 	}
 	// Archive extensions we can handle.
 	archiveExtensions = []string{
@@ -88,23 +92,33 @@ func MatchAssets(assets []Asset, repoName, assetFilter string) []Scored {
 	}
 
 	var candidates []Scored
+	repoLower := strings.ToLower(repoName)
 
 	for i := range assets {
 		a := &assets[i]
 		name := a.Name
 		lower := strings.ToLower(name)
 
-		// Skip known non-binary extensions
-		if shouldIgnore(lower) {
-			continue
-		}
-
-		// Apply asset filter glob if provided
+		// Apply asset filter glob if provided — explicit filter takes priority
+		// over the non-binary extension blocklist (user knows what they want).
 		if assetFilter != "" {
 			matched, _ := filepath.Match(filterLower, lower)
 			if !matched {
 				continue
 			}
+		} else if shouldIgnore(lower) {
+			// No filter — skip known non-binary extensions.
+			continue
+		}
+
+		// Portable fallback: an asset whose filename equals the repo name
+		// (optionally with a script extension like .sh/.py/.pl) is likely a
+		// platform-independent script or universal binary. Score it the
+		// same as a typical OS/arch-matched asset so it's surfaced as a
+		// candidate (and triggers the interactive picker when tied).
+		if repoLower != "" && isPortableName(lower, repoLower) {
+			candidates = append(candidates, Scored{Asset: a, Score: 13})
+			continue
 		}
 
 		// Must match OS
@@ -175,6 +189,26 @@ func DetectArchiveType(name string) string {
 		return "zip"
 	}
 	return ""
+}
+
+// portableScriptExts are extensions commonly used by portable (interpreted)
+// scripts that don't target a specific OS/arch.
+var portableScriptExts = []string{".sh", ".py", ".pl", ".rb", ".js"}
+
+// isPortableName reports whether assetLower is the repo name on its own
+// (e.g. "argsh") or the repo name with a common script extension
+// (e.g. "tool.sh"). Used to keep platform-independent assets as candidates
+// even though they contain no OS/arch marker.
+func isPortableName(assetLower, repoLower string) bool {
+	if assetLower == repoLower {
+		return true
+	}
+	for _, ext := range portableScriptExts {
+		if assetLower == repoLower+ext {
+			return true
+		}
+	}
+	return false
 }
 
 // shouldIgnore returns true if the filename should be skipped.

--- a/pkg/provider/detect.go
+++ b/pkg/provider/detect.go
@@ -42,6 +42,16 @@ var (
 	}
 )
 
+// Asset scoring weights. Exposed as named constants so the portable-name
+// fallback stays aligned with the "typical OS/arch match" score even if the
+// scoring formula changes.
+const (
+	scoreOSArchMatch  = 10 // base: OS + arch both matched
+	scoreArchiveBonus = 5  // prefer archives (more likely to contain the binary)
+	scoreRepoNameHit  = 3  // asset filename contains the repo name
+	scoreTarGzBonus   = 1  // prefer tar.gz over other archives
+)
+
 // Scored is a scored asset candidate, exported for interactive selection.
 type Scored struct {
 	Asset *Asset
@@ -114,10 +124,11 @@ func MatchAssets(assets []Asset, repoName, assetFilter string) []Scored {
 		// Portable fallback: an asset whose filename equals the repo name
 		// (optionally with a script extension like .sh/.py/.pl) is likely a
 		// platform-independent script or universal binary. Score it the
-		// same as a typical OS/arch-matched asset so it's surfaced as a
-		// candidate (and triggers the interactive picker when tied).
+		// same as a typical OS/arch-matched asset that also has the repo
+		// name in its filename, so it surfaces in the interactive picker
+		// alongside those candidates.
 		if repoLower != "" && isPortableName(lower, repoLower) {
-			candidates = append(candidates, Scored{Asset: a, Score: 13})
+			candidates = append(candidates, Scored{Asset: a, Score: scoreOSArchMatch + scoreRepoNameHit})
 			continue
 		}
 
@@ -146,21 +157,21 @@ func MatchAssets(assets []Asset, repoName, assetFilter string) []Scored {
 		}
 
 		// Score: higher is better
-		score := 10 // base: matched OS + arch
+		score := scoreOSArchMatch
 
 		// Prefer archives (more likely to contain the right binary)
 		if isArchive(lower) {
-			score += 5
+			score += scoreArchiveBonus
 		}
 
 		// Prefer asset name containing repo name
 		if repoName != "" && containsWord(lower, strings.ToLower(repoName)) {
-			score += 3
+			score += scoreRepoNameHit
 		}
 
 		// Prefer tar.gz over zip (more common in Go/Rust ecosystem)
 		if strings.HasSuffix(lower, ".tar.gz") || strings.HasSuffix(lower, ".tgz") {
-			score += 1
+			score += scoreTarGzBonus
 		}
 
 		candidates = append(candidates, Scored{Asset: a, Score: score})
@@ -211,8 +222,18 @@ func isPortableName(assetLower, repoLower string) bool {
 	return false
 }
 
+// libraryInfixes catches versioned shared-library filenames whose extension
+// doesn't end in exactly ".so"/".dylib"/".dll" — e.g. "libfoo.so.1.2",
+// "libbar.dylib.4", "baz.dll.5.0".
+var libraryInfixes = []string{".so.", ".dylib.", ".dll."}
+
 // shouldIgnore returns true if the filename should be skipped.
 func shouldIgnore(lower string) bool {
+	for _, inf := range libraryInfixes {
+		if strings.Contains(lower, inf) {
+			return true
+		}
+	}
 	for _, ext := range ignoreExtensions {
 		if strings.HasSuffix(lower, ext) {
 			return true

--- a/pkg/provider/detect_test.go
+++ b/pkg/provider/detect_test.go
@@ -157,6 +157,76 @@ func TestMatchAssetWithFilter(t *testing.T) {
 	}
 }
 
+// TestMatchAssets_ArgshScriptIsVisible reproduces the argsh release layout
+// where the main asset is a bare portable script and the rest are shared
+// libraries or VS Code bundles. The bare script must appear as a candidate.
+func TestMatchAssets_ArgshScriptIsVisible(t *testing.T) {
+	if runtime.GOOS != "linux" || runtime.GOARCH != "amd64" {
+		t.Skip("test requires linux/amd64")
+	}
+	assets := []Asset{
+		{Name: "argsh"},                  // portable bash script (THE binary)
+		{Name: "argsh-linux-amd64.so"},   // shared library
+		{Name: "argsh-linux-arm64.so"},   // shared library
+		{Name: "argsh-linux-x64.vsix"},   // VS Code extension
+		{Name: "argsh-so-linux-amd64"},   // shared library (no .so ext)
+		{Name: "argsh-darwin-arm64.vsix"},
+		{Name: "argsh-darwin-x64.vsix"},
+	}
+	candidates := MatchAssets(assets, "argsh", "")
+
+	// The bare "argsh" script must tie with the top-scored candidate so the
+	// interactive picker surfaces it as a choice.
+	if len(candidates) == 0 {
+		t.Fatal("expected candidates, got none")
+	}
+	topScore := candidates[0].Score
+	foundBare := false
+	for _, c := range candidates {
+		if c.Asset.Name == "argsh" && c.Score == topScore {
+			foundBare = true
+		}
+	}
+	if !foundBare {
+		names := make([]string, len(candidates))
+		for i, c := range candidates {
+			names[i] = c.Asset.Name
+		}
+		t.Errorf("bare 'argsh' script missing or not top-scored; candidates: %v", names)
+	}
+
+	// Libraries (.so, .vsix) must be filtered out by default.
+	for _, c := range candidates {
+		switch c.Asset.Name {
+		case "argsh-linux-amd64.so", "argsh-linux-arm64.so",
+			"argsh-linux-x64.vsix", "argsh-darwin-arm64.vsix", "argsh-darwin-x64.vsix":
+			t.Errorf("library asset %q should have been filtered", c.Asset.Name)
+		}
+	}
+}
+
+// TestIsPortableName covers the portable script name detection helper.
+func TestIsPortableName(t *testing.T) {
+	tests := []struct {
+		asset string
+		repo  string
+		want  bool
+	}{
+		{"argsh", "argsh", true},
+		{"argsh.sh", "argsh", true},
+		{"tool.py", "tool", true},
+		{"argsh-linux-amd64", "argsh", false},
+		{"argsh.so", "argsh", false}, // handled by extension filter, not portable fallback
+		{"other", "argsh", false},
+	}
+	for _, tt := range tests {
+		got := isPortableName(tt.asset, tt.repo)
+		if got != tt.want {
+			t.Errorf("isPortableName(%q, %q) = %v, want %v", tt.asset, tt.repo, got, tt.want)
+		}
+	}
+}
+
 // TestMatchAssets_SortedByScore tests that MatchAssets returns sorted results.
 func TestMatchAssets_SortedByScore(t *testing.T) {
 	if runtime.GOOS != "linux" || runtime.GOARCH != "amd64" {

--- a/pkg/provider/detect_test.go
+++ b/pkg/provider/detect_test.go
@@ -165,11 +165,13 @@ func TestMatchAssets_ArgshScriptIsVisible(t *testing.T) {
 		t.Skip("test requires linux/amd64")
 	}
 	assets := []Asset{
-		{Name: "argsh"},                  // portable bash script (THE binary)
-		{Name: "argsh-linux-amd64.so"},   // shared library
-		{Name: "argsh-linux-arm64.so"},   // shared library
-		{Name: "argsh-linux-x64.vsix"},   // VS Code extension
-		{Name: "argsh-so-linux-amd64"},   // shared library (no .so ext)
+		{Name: "argsh"},                            // portable bash script (THE binary)
+		{Name: "argsh-linux-amd64.so"},             // shared library
+		{Name: "argsh-linux-arm64.so"},             // shared library
+		{Name: "libargsh-linux-amd64.so.1"},        // versioned shared library
+		{Name: "libargsh.dylib.2.0.0-linux-amd64"}, // versioned dylib with OS/arch
+		{Name: "argsh-linux-x64.vsix"},             // VS Code extension
+		{Name: "argsh-so-linux-amd64"},             // shared library (no .so ext)
 		{Name: "argsh-darwin-arm64.vsix"},
 		{Name: "argsh-darwin-x64.vsix"},
 	}
@@ -195,12 +197,40 @@ func TestMatchAssets_ArgshScriptIsVisible(t *testing.T) {
 		t.Errorf("bare 'argsh' script missing or not top-scored; candidates: %v", names)
 	}
 
-	// Libraries (.so, .vsix) must be filtered out by default.
+	// Libraries (.so, .so.N, .dylib.N, .vsix) must be filtered out by default.
 	for _, c := range candidates {
 		switch c.Asset.Name {
 		case "argsh-linux-amd64.so", "argsh-linux-arm64.so",
+			"libargsh-linux-amd64.so.1", "libargsh.dylib.2.0.0-linux-amd64",
 			"argsh-linux-x64.vsix", "argsh-darwin-arm64.vsix", "argsh-darwin-x64.vsix":
 			t.Errorf("library asset %q should have been filtered", c.Asset.Name)
+		}
+	}
+}
+
+// TestShouldIgnore_Libraries verifies both suffix-based (libfoo.so) and
+// versioned infix-based (libfoo.so.1, libbar.dylib.2, baz.dll.5) shared
+// library filenames are filtered out by default.
+func TestShouldIgnore_Libraries(t *testing.T) {
+	tests := []struct {
+		name string
+		want bool
+	}{
+		{"libfoo.so", true},
+		{"libfoo.so.1", true},
+		{"libfoo.so.1.2.3", true},
+		{"libbar.dylib", true},
+		{"libbar.dylib.2.0.0", true},
+		{"libbaz.dll", true},
+		{"libbaz.dll.5.0", true},
+		{"plugin.vsix", true},
+		{"something.jar", true},
+		{"tool-linux-amd64", false},
+		{"tool.tar.gz", false},
+	}
+	for _, tt := range tests {
+		if got := shouldIgnore(tt.name); got != tt.want {
+			t.Errorf("shouldIgnore(%q) = %v, want %v", tt.name, got, tt.want)
 		}
 	}
 }


### PR DESCRIPTION
## Summary
Three connected asset-matching fixes driven by `b install github.com/arg-sh/argsh`:

**1. Filter library/plugin bundles as default non-binaries.**
`ignoreExtensions` now includes `.so`, `.dylib`, `.dll`, `.a`, `.lib`, `.jar`, `.aar`, `.vsix`. These are never CLI executables. When a user passes an explicit `--asset <glob>`, the filter still takes priority over this blocklist — they know what they want.

**2. Portable-name fallback.**
An asset whose filename equals the repo name (optionally with a script extension: `.sh`/`.py`/`.pl`/`.rb`/`.js`) is treated as a candidate even without an OS/arch marker. Scored on par with typical OS/arch matches so it ties with them and surfaces in the interactive picker.

**3. Persist the interactive pick to `b.yaml`.**
Previously, `b install --add github.com/arg-sh/argsh` ran the prompt once but didn't save the choice, so `b update` re-prompted (or silently auto-picked a possibly different asset). When the real interactive picker is used (TTY + not quiet + user picks), the chosen asset name is now written to `AssetFilter` → `entry.Asset` in `b.yaml`. Subsequent `b update` loads it back and `MatchAssets` narrows to that exact asset. Quiet / non-TTY auto-picks are **not** persisted because the user never saw or consented to the choice.

## Before / after

Before:
```
Multiple assets match for argsh. Select one:
  [1] argsh-linux-amd64.so  (522.7 KB)     # shared library
  [2] argsh-linux-x64.vsix  (2.4 MB)       # VS Code extension
  [3] argsh-so-linux-amd64  (558.5 KB)     # also a shared library
```
And `b install --add` did not persist the choice.

After:
```
Multiple assets match for argsh. Select one:
  [1] argsh                  (34.6 KB)     # the actual CLI bash script
  [2] argsh-so-linux-amd64   (558.5 KB)
```
With `--add`, the picked asset is written to `b.yaml` as `asset: <name>` and `b update` keeps using it.

## Test plan
- [x] `TestMatchAssets_ArgshScriptIsVisible` reproduces the argsh release layout.
- [x] `TestIsPortableName` covers the helper.
- [x] `TestMatchAssetWithFilter` unchanged — explicit `--asset` glob still works for `.so`.
- [x] `TestResolveAmbiguousAssets_Interactive_PersistsChoice` covers persistence with mocked TTY + stdin.
- [x] `TestResolveAmbiguousAssets_QuietAutoPick_DoesNotPersist` ensures quiet auto-pick does not pin.
- [x] `go test ./...` — all 39 packages pass.
- [x] Manual end-to-end: `b install github.com/arg-sh/argsh` now installs the 35 KB bash script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)