### PR TITLE
fix(preset,binary): argsh update stuck at old version

### DIFF
--- a/pkg/binaries/argsh/argsh.go
+++ b/pkg/binaries/argsh/argsh.go
@@ -24,12 +24,19 @@ func Binary(options *binaries.BinaryOptions) *binary.Binary {
 		GitHubFile: "argsh",
 		VersionF:   binary.GithubLatest,
 		VersionLocalF: func(b *binary.Binary) (string, error) {
-			s, err := b.Exec("version")
+			// argsh prints 'argsh v0.6.6 (<sha>)' to stdout for --version.
+			// Parse the second whitespace-separated token so b's version
+			// compare sees 'v0.6.6' instead of the commit sha that the
+			// old 'strings.Split(s, " ")[last]' yielded.
+			s, err := b.Exec("--version")
 			if err != nil {
 				return "", err
 			}
-			v := strings.Split(s, " ")
-			return v[len(v)-1], nil
+			fields := strings.Fields(s)
+			if len(fields) < 2 {
+				return "", nil
+			}
+			return fields[1], nil
 		},
 	}
 }

--- a/pkg/binary/binary.go
+++ b/pkg/binary/binary.go
@@ -61,8 +61,14 @@ func (b *Binary) EnsureBinary(update bool) error {
 		}
 		local := b.LocalBinary(true)
 
-		if local.Version == local.Enforced || local.Enforced == "" && local.Latest == local.Version {
-			return nil
+		// Don't short-circuit when we can't tell what's installed. An empty
+		// local.Version here means VersionLocalF either didn't run or
+		// errored (e.g. preset uses the wrong subcommand and the binary
+		// errors out); we must not mistake that for "matches the pin".
+		if local.Version != "" {
+			if local.Version == local.Enforced || local.Enforced == "" && local.Latest == local.Version {
+				return nil
+			}
 		}
 	}
 

--- a/pkg/binary/binary_test.go
+++ b/pkg/binary/binary_test.go
@@ -273,7 +273,6 @@ func TestBinary_EnsureBinary_UpdateWhenLocalVersionUnknown(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(tmp, "broken"), []byte("stale"), 0755); err != nil {
 		t.Fatal(err)
 	}
-	downloadCalled := false
 	b := &Binary{
 		Name: "broken",
 		// No pin.
@@ -287,14 +286,19 @@ func TestBinary_EnsureBinary_UpdateWhenLocalVersionUnknown(t *testing.T) {
 			// VersionLocalF has no version to report.
 			return "", os.ErrNotExist
 		},
-		// No URL/URLF/GitHubRepo so DownloadBinary will return an error —
-		// we use that as a sentinel that the skip path was bypassed.
+		// No URL/URLF/GitHubRepo so DownloadBinary will fail with
+		// "no URL provided". That error is our sentinel: it proves the
+		// download branch ran instead of the broken skip path. Before
+		// the fix EnsureBinary returned nil here (Version=="" ==
+		// Enforced=="") and the preset silently appeared up to date.
 	}
 	err := b.EnsureBinary(true)
 	if err == nil {
 		t.Fatal("expected DownloadBinary to be attempted (and fail without a download source), got nil")
 	}
-	_ = downloadCalled
+	if !strings.Contains(err.Error(), "no URL provided") {
+		t.Errorf("expected the 'no URL provided' sentinel error, got: %v", err)
+	}
 }
 
 // --- exec.go ---

--- a/pkg/binary/binary_test.go
+++ b/pkg/binary/binary_test.go
@@ -258,6 +258,45 @@ func TestBinary_EnsureBinary_UpdateUpToDate(t *testing.T) {
 	}
 }
 
+// TestBinary_EnsureBinary_UpdateWhenLocalVersionUnknown guards against a
+// regression where a preset whose VersionLocalF errored (e.g. the binary
+// doesn't support the expected subcommand) would silently skip updates —
+// local.Version="" == local.Enforced="" used to satisfy the skip check,
+// so 'b update' did nothing even when the upstream release had moved.
+//
+// Now an empty local.Version means "unknown"; EnsureBinary must proceed
+// to DownloadBinary instead of early-returning.
+func TestBinary_EnsureBinary_UpdateWhenLocalVersionUnknown(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("PATH_BIN", tmp)
+	// Pre-existing binary on disk, so the BinaryExists branch runs.
+	if err := os.WriteFile(filepath.Join(tmp, "broken"), []byte("stale"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	downloadCalled := false
+	b := &Binary{
+		Name: "broken",
+		// No pin.
+		Version: "",
+		VersionF: func(b *Binary) (string, error) {
+			return "v2", nil // upstream has a newer version
+		},
+		VersionLocalF: func(b *Binary) (string, error) {
+			// Preset's probe command failed — classic 'argsh version' bug:
+			// subcommand doesn't exist so the binary exits non-zero and
+			// VersionLocalF has no version to report.
+			return "", os.ErrNotExist
+		},
+		// No URL/URLF/GitHubRepo so DownloadBinary will return an error —
+		// we use that as a sentinel that the skip path was bypassed.
+	}
+	err := b.EnsureBinary(true)
+	if err == nil {
+		t.Fatal("expected DownloadBinary to be attempted (and fail without a download source), got nil")
+	}
+	_ = downloadCalled
+}
+
 // --- exec.go ---
 
 func TestBinary_Env(t *testing.T) {

--- a/pkg/state/yamlmerge.go
+++ b/pkg/state/yamlmerge.go
@@ -35,8 +35,9 @@ func managedKey(path []string, key string) bool {
 		// preserved verbatim.
 		switch path[0] {
 		case "binaries":
+			// Matches BinaryList.MarshalYAML.
 			switch key {
-			case "version", "alias", "file", "asset":
+			case "version", "enforced", "alias", "file", "asset":
 				return true
 			}
 			return false


### PR DESCRIPTION
## Summary
\`b u argsh\` stayed on the currently-installed version forever even when upstream had a newer release. Two compounding bugs:

**1. \`pkg/binaries/argsh/argsh.go\`** — \`VersionLocalF\` ran \`argsh version\`, but argsh accepts \`--version\` (no subcommand). The exec returned a non-zero exit so \`VersionLocalF\` returned \`("", err)\`. Even if the subcommand had worked, the parser split the output on whitespace and took the **last** token, which for real output \`argsh v0.6.5 (<sha>)\` was the commit sha, not the version.

Fix: call \`--version\`, use \`strings.Fields\`, and grab \`fields[1]\` → \`v0.6.5\`.

**2. \`pkg/binary/binary.go\`** — \`EnsureBinary\`'s skip check was:
\`\`\`go
if local.Version == local.Enforced || local.Enforced == "" && local.Latest == local.Version {
    return nil
}
\`\`\`
When \`VersionLocalF\` errors, \`LocalBinary\` swallows the error and sets \`version=""\`. The check then matches \`"" == ""\` and returns nil. Net effect: any preset whose version probe breaks silently skips every update.

Fix: treat \`local.Version == ""\` as "unknown" and fall through to \`DownloadBinary\` instead of short-circuiting.

This is a **latent-bug class** — beyond argsh, any preset with a broken version probe (or a new CLI where the probed subcommand was removed) was failing silently. The fix is at the framework level so future presets can't hit the same wall.

## Also in this PR
\`managedKey\` in \`pkg/state/yamlmerge.go\` was missing \`enforced\` at \`binaries.<name>\` — \`BinaryList.MarshalYAML\` emits \`enforced:\` (added in #149) but \`managedKey\` (landed in #148, slightly earlier) didn't know about it. \`TestManagedKey_MatchesMarshalOutput\` was red on main. Fixed here because the fix is in the same small surface area.

## Test plan
- [x] \`TestBinary_EnsureBinary_UpdateWhenLocalVersionUnknown\` — guards against the silent-skip regression.
- [x] Existing \`TestBinary_argsh\` still passes (binary generation unchanged).
- [x] \`go test ./...\` — all 39 packages pass.
- [x] End-to-end: \`b u argsh\` now moves from v0.6.5 → v0.6.6 (verified with a local build against \`github.com/kernpilot/lok8s\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)