### PR TITLE
fix(preset): disable tilt analytics during version check

### DIFF
--- a/pkg/binaries/tilt/tilt.go
+++ b/pkg/binaries/tilt/tilt.go
@@ -33,6 +33,13 @@ func Binary(options *binaries.BinaryOptions) *binary.Binary {
 		VersionF: binary.GithubLatest,
 		IsTarGz:  true,
 		VersionLocalF: func(b *binary.Binary) (string, error) {
+			// tilt's analytics init calls getent which may not be in
+			// the clean env. Disable analytics so the version check
+			// doesn't fail on minimal environments.
+			if b.Envs == nil {
+				b.Envs = map[string]string{}
+			}
+			b.Envs["TILT_DISABLE_ANALYTICS"] = "1"
 			s, err := b.Exec("version")
 			if err != nil {
 				return "", err


### PR DESCRIPTION
## Summary
\`tilt version\` fails in b's clean exec environment because tilt's analytics init calls \`getent\` which isn't available. This left \`VersionLocalF\` unable to report the installed version.

## Fix
Set \`TILT_DISABLE_ANALYTICS=1\` inside \`VersionLocalF\`, same pattern as:
- k9s: \`K9S_LOGS_DIR=/tmp\`
- argocd: \`HOME=/tmp\`
- packer: \`HOME=/tmp\`

## Test plan
- [x] \`go test ./...\` — all 39 packages pass
- [x] With the EnsureBinary revert from #156, tilt's version check now succeeds → no more 41MB re-downloads on every \`b update\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)