### PR TITLE
fix(state): keep relative file paths on save; clearer install errors

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"d6555f10-bc04-48d5-b005-56ba55419f43","pid":2922609,"procStart":"119208340","acquiredAt":1780412977343}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"d6555f10-bc04-48d5-b005-56ba55419f43","pid":2922609,"procStart":"119208340","acquiredAt":1780412977343}

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ main
 !/test/coverage/coverage.json
 
 .mise.toml
+
+/.claude/

--- a/pkg/binaries/renvsubst/renvsubst.go
+++ b/pkg/binaries/renvsubst/renvsubst.go
@@ -40,7 +40,7 @@ func Binary(options *binaries.BinaryOptions) *binary.Binary {
 		GitHubFileF: func(b *binary.Binary) (string, error) {
 			s := sys()
 			if s == "" {
-				return "", fmt.Errorf("unsupported platform: %s/%s", runtime.GOOS, runtime.GOARCH)
+				return "", fmt.Errorf("no %s/%s build for %s", runtime.GOOS, runtime.GOARCH, b.Name)
 			}
 			return fmt.Sprintf("renvsubst-%s-%s.tar.gz",
 				b.Version,

--- a/pkg/binary/download.go
+++ b/pkg/binary/download.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/fentas/b/pkg/provider"
@@ -481,7 +482,14 @@ func (b *Binary) downloadPreset() error {
 			if b.VersionF != nil {
 				latest, _ = b.VersionF(b)
 			}
-			return fmt.Errorf("%s not found ^^ %s", b.Version, latest)
+			// A 404 on the download URL means the requested version+platform
+			// asset doesn't exist. If the requested version differs from the
+			// latest, the version is the likely culprit; otherwise the version
+			// is fine and there's simply no asset for this OS/arch.
+			if latest != "" && latest != b.Version {
+				return fmt.Errorf("%s %s not found (latest: %s)", b.Name, b.Version, latest)
+			}
+			return fmt.Errorf("%s %s not found for %s/%s", b.Name, b.Version, runtime.GOOS, runtime.GOARCH)
 		case http.StatusForbidden:
 		case http.StatusUnauthorized:
 			return fmt.Errorf("Unauthorized")

--- a/pkg/state/config.go
+++ b/pkg/state/config.go
@@ -63,9 +63,9 @@ func SaveConfig(config *State, configPath string) error {
 	// process sees a real on-disk location. Reverse that here so a
 	// load→modify→save round-trip (e.g. `b install --add`) keeps the user's
 	// relative `file:` values relative instead of rewriting them to absolute
-	// paths. Mutate-and-restore avoids changing the caller's in-memory state,
-	// which must stay absolute for the rest of the process.
-	defer relativizeFiles(config, dir)()
+	// paths. relativizeFiles works on a copy, so the caller's in-memory state
+	// is left untouched (it must stay absolute, and may be read concurrently).
+	config = relativizeFiles(config, dir)
 
 	// Try comment-preserving save if file exists
 	if _, err := os.Stat(configPath); err == nil {
@@ -75,37 +75,36 @@ func SaveConfig(config *State, configPath string) error {
 	return saveConfigClean(config, configPath)
 }
 
-// relativizeFiles temporarily converts each binary's absolute File path that
-// lives under configDir back to a path relative to configDir, returning a
-// function that restores the original values. Paths that are already relative,
-// or absolute paths outside configDir, are left untouched. This is the inverse
-// of the join performed in LoadConfigFromPath.
-func relativizeFiles(config *State, configDir string) func() {
+// relativizeFiles returns a copy of config in which each binary's absolute File
+// path that lives under configDir is rewritten relative to configDir — the
+// inverse of the join performed in LoadConfigFromPath. The input config and its
+// binaries are never mutated; unchanged binaries are shared by pointer. Paths
+// that are already relative, or absolute paths outside configDir, are left
+// as-is.
+func relativizeFiles(config *State, configDir string) *State {
 	if config == nil {
-		return func() {}
+		return nil
 	}
-	type saved struct {
-		b    *binary.LocalBinary
-		file string
-	}
-	var originals []saved
-	for _, b := range config.Binaries {
+	out := *config // shallow copy; Envs/Profiles are untouched and shared
+	bins := make(BinaryList, len(config.Binaries))
+	for i, b := range config.Binaries {
 		if b == nil || b.File == "" || !filepath.IsAbs(b.File) {
+			bins[i] = b
 			continue
 		}
 		rel, err := filepath.Rel(configDir, b.File)
-		if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
-			// Outside the config dir — keep it absolute.
+		if err != nil || rel == "." || rel == ".." ||
+			strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+			// Outside (or equal to) the config dir — keep it absolute.
+			bins[i] = b
 			continue
 		}
-		originals = append(originals, saved{b, b.File})
-		b.File = rel
+		clone := *b
+		clone.File = rel
+		bins[i] = &clone
 	}
-	return func() {
-		for _, s := range originals {
-			s.b.File = s.file
-		}
-	}
+	out.Binaries = bins
+	return &out
 }
 
 // saveConfigClean does a plain marshal+write without preserving comments.

--- a/pkg/state/config.go
+++ b/pkg/state/config.go
@@ -3,6 +3,7 @@ package state
 import (
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/fentas/b/pkg/binary"
 	"github.com/fentas/b/pkg/path"
@@ -58,12 +59,53 @@ func SaveConfig(config *State, configPath string) error {
 		return err
 	}
 
+	// LoadConfigFromPath absolutizes relative `file:` paths so the running
+	// process sees a real on-disk location. Reverse that here so a
+	// load→modify→save round-trip (e.g. `b install --add`) keeps the user's
+	// relative `file:` values relative instead of rewriting them to absolute
+	// paths. Mutate-and-restore avoids changing the caller's in-memory state,
+	// which must stay absolute for the rest of the process.
+	defer relativizeFiles(config, dir)()
+
 	// Try comment-preserving save if file exists
 	if _, err := os.Stat(configPath); err == nil {
 		return SaveConfigPreserving(config, configPath)
 	}
 
 	return saveConfigClean(config, configPath)
+}
+
+// relativizeFiles temporarily converts each binary's absolute File path that
+// lives under configDir back to a path relative to configDir, returning a
+// function that restores the original values. Paths that are already relative,
+// or absolute paths outside configDir, are left untouched. This is the inverse
+// of the join performed in LoadConfigFromPath.
+func relativizeFiles(config *State, configDir string) func() {
+	if config == nil {
+		return func() {}
+	}
+	type saved struct {
+		b    *binary.LocalBinary
+		file string
+	}
+	var originals []saved
+	for _, b := range config.Binaries {
+		if b == nil || b.File == "" || !filepath.IsAbs(b.File) {
+			continue
+		}
+		rel, err := filepath.Rel(configDir, b.File)
+		if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+			// Outside the config dir — keep it absolute.
+			continue
+		}
+		originals = append(originals, saved{b, b.File})
+		b.File = rel
+	}
+	return func() {
+		for _, s := range originals {
+			s.b.File = s.file
+		}
+	}
 }
 
 // saveConfigClean does a plain marshal+write without preserving comments.

--- a/pkg/state/config.go
+++ b/pkg/state/config.go
@@ -75,12 +75,18 @@ func SaveConfig(config *State, configPath string) error {
 	return saveConfigClean(config, configPath)
 }
 
-// relativizeFiles returns a copy of config in which each binary's absolute File
-// path that lives under configDir is rewritten relative to configDir — the
-// inverse of the join performed in LoadConfigFromPath. The input config and its
-// binaries are never mutated; unchanged binaries are shared by pointer. Paths
-// that are already relative, or absolute paths outside configDir, are left
-// as-is.
+// relativizeFiles returns a copy of config in which each binary's File path
+// that lives under configDir is rewritten relative to configDir — the inverse
+// of the join performed in LoadConfigFromPath. The input config and its
+// binaries are never mutated; unchanged binaries are shared by pointer.
+//
+// LoadConfigFromPath joins relative `file:` values against configDir; when
+// configPath itself is relative (e.g. `--config ./custom/b.yaml` or the
+// `.bin/b.yaml` default) the joined path stays relative, so we cannot gate on
+// filepath.IsAbs here. filepath.Rel handles both cases: it relativizes a path
+// under configDir and errors (or yields a `..`/`.` prefix) for anything that
+// isn't — including a user-supplied absolute path against a relative configDir
+// — which we skip, leaving such values untouched.
 func relativizeFiles(config *State, configDir string) *State {
 	if config == nil {
 		return nil
@@ -88,14 +94,14 @@ func relativizeFiles(config *State, configDir string) *State {
 	out := *config // shallow copy; Envs/Profiles are untouched and shared
 	bins := make(BinaryList, len(config.Binaries))
 	for i, b := range config.Binaries {
-		if b == nil || b.File == "" || !filepath.IsAbs(b.File) {
+		if b == nil || b.File == "" {
 			bins[i] = b
 			continue
 		}
 		rel, err := filepath.Rel(configDir, b.File)
 		if err != nil || rel == "." || rel == ".." ||
 			strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
-			// Outside (or equal to) the config dir — keep it absolute.
+			// Outside (or equal to) the config dir — leave it as-is.
 			bins[i] = b
 			continue
 		}

--- a/pkg/state/config.go
+++ b/pkg/state/config.go
@@ -59,12 +59,13 @@ func SaveConfig(config *State, configPath string) error {
 		return err
 	}
 
-	// LoadConfigFromPath absolutizes relative `file:` paths so the running
-	// process sees a real on-disk location. Reverse that here so a
-	// load→modify→save round-trip (e.g. `b install --add`) keeps the user's
-	// relative `file:` values relative instead of rewriting them to absolute
-	// paths. relativizeFiles works on a copy, so the caller's in-memory state
-	// is left untouched (it must stay absolute, and may be read concurrently).
+	// LoadConfigFromPath resolves relative `file:` values against the config
+	// dir so the running process sees a usable on-disk location. Reverse that
+	// here so a load→modify→save round-trip (e.g. `b install --add`) keeps the
+	// user's relative `file:` values relative instead of rewriting them to the
+	// resolved path. relativizeFiles works on a copy, so the caller's in-memory
+	// state is left untouched (it must stay resolved, and may be read
+	// concurrently).
 	config = relativizeFiles(config, dir)
 
 	// Try comment-preserving save if file exists

--- a/pkg/state/config_test.go
+++ b/pkg/state/config_test.go
@@ -81,6 +81,58 @@ func TestSaveConfig_KeepsRelativeFilePaths(t *testing.T) {
 	}
 }
 
+// TestSaveConfig_KeepsRelativeFilePaths_RelativeConfigPath covers the case
+// Copilot flagged: when configPath is relative, LoadConfigFromPath joins
+// `file:` into a still-relative path (e.g. ".bin/jira"), so the relativize on
+// save must not gate on filepath.IsAbs — otherwise the round-trip rewrites
+// "jira" to ".bin/jira".
+func TestSaveConfig_KeepsRelativeFilePaths_RelativeConfigPath(t *testing.T) {
+	tmpDir := t.TempDir()
+	binDir := filepath.Join(tmpDir, ".bin")
+	if err := os.MkdirAll(binDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Run with cwd == tmpDir so a relative config path resolves correctly.
+	t.Chdir(tmpDir)
+
+	relConfigPath := filepath.Join(".bin", "b.yaml") // relative, with a dir component
+	initial := `binaries:
+  github.com/ankitpokhrel/jira-cli:
+    file: jira
+  jq: {}
+`
+	if err := os.WriteFile(relConfigPath, []byte(initial), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	config, err := LoadConfigFromPath(relConfigPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Sanity: load produced a still-relative joined path (the trigger).
+	if got := mustFile(config, "github.com/ankitpokhrel/jira-cli"); got != filepath.Join(".bin", "jira") {
+		t.Fatalf("expected joined-but-relative %q, got %q", filepath.Join(".bin", "jira"), got)
+	}
+
+	config.Binaries = append(config.Binaries, &binary.LocalBinary{Name: "yq"})
+	if err := SaveConfig(config, relConfigPath); err != nil {
+		t.Fatal(err)
+	}
+
+	data, err := os.ReadFile(relConfigPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(data)
+	if !strings.Contains(got, "file: jira\n") {
+		t.Errorf("expected jira-cli to keep 'file: jira', got:\n%s", got)
+	}
+	if strings.Contains(got, ".bin/jira") {
+		t.Errorf("file: path leaked the config dir prefix, got:\n%s", got)
+	}
+}
+
 // TestSaveConfig_KeepsRelativeFilePaths_NewFile covers the clean-save path
 // (no pre-existing file), where the binaries are marshaled from scratch.
 func TestSaveConfig_KeepsRelativeFilePaths_NewFile(t *testing.T) {

--- a/pkg/state/config_test.go
+++ b/pkg/state/config_test.go
@@ -62,8 +62,9 @@ func TestSaveConfig_KeepsRelativeFilePaths(t *testing.T) {
 		t.Errorf("config should not contain absolute paths (%s), got:\n%s", tmpDir, got)
 	}
 
-	// In-memory state must be restored to absolute so the running process is
-	// unaffected by the save.
+	// SaveConfig must not mutate the caller's in-memory state — the paths it
+	// relativizes for disk are written to a copy, so the live config keeps the
+	// absolute paths the running process depends on.
 	if khelm := config.Binaries.Get("khelm"); khelm == nil || !filepath.IsAbs(khelm.File) {
 		t.Errorf("expected khelm.File to remain absolute in memory after save, got %q", mustFile(config, "khelm"))
 	}
@@ -112,22 +113,29 @@ func TestSaveConfig_KeepsRelativeFilePaths_NewFile(t *testing.T) {
 }
 
 // TestRelativizeFiles_LeavesOutsidePathsAbsolute ensures absolute File paths
-// that don't live under the config dir are preserved verbatim.
+// that don't live under the config dir (and the degenerate "equals configDir"
+// case) are preserved verbatim, and that the input config is never mutated.
 func TestRelativizeFiles_LeavesOutsidePathsAbsolute(t *testing.T) {
+	configDir := filepath.Join(string(filepath.Separator)+"home", "user", ".bin")
 	outside := filepath.Join(string(filepath.Separator)+"opt", "bin", "tool")
 	config := &State{
 		Binaries: BinaryList{
 			&binary.LocalBinary{Name: "tool", File: outside},
+			&binary.LocalBinary{Name: "self", File: configDir}, // rel would be "."
 		},
 	}
 
-	restore := relativizeFiles(config, filepath.Join(string(filepath.Separator)+"home", "user", ".bin"))
-	if got := mustFile(config, "tool"); got != outside {
+	out := relativizeFiles(config, configDir)
+
+	if got := mustFile(out, "tool"); got != outside {
 		t.Errorf("outside path should stay absolute, got %q", got)
 	}
-	restore()
+	if got := mustFile(out, "self"); got != configDir {
+		t.Errorf("path equal to configDir should stay absolute, got %q", got)
+	}
+	// Input must be untouched (no-mutation contract).
 	if got := mustFile(config, "tool"); got != outside {
-		t.Errorf("restore changed an untouched path, got %q", got)
+		t.Errorf("input config was mutated, got %q", got)
 	}
 }
 

--- a/pkg/state/config_test.go
+++ b/pkg/state/config_test.go
@@ -1,0 +1,139 @@
+package state
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/fentas/b/pkg/binary"
+)
+
+// TestSaveConfig_KeepsRelativeFilePaths verifies that a load→modify→save
+// round-trip (as performed by `b install --add`) does not rewrite the user's
+// relative `file:` values to absolute paths. LoadConfigFromPath absolutizes
+// them in memory; SaveConfig must reverse that on the way out.
+func TestSaveConfig_KeepsRelativeFilePaths(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "b.yaml")
+
+	initial := `binaries:
+  github.com/ankitpokhrel/jira-cli:
+    file: jira
+  khelm:
+    file: .kustomize/khelm.mgoltzsche.github.com/v2/chartrenderer/ChartRenderer
+  jq: {}
+`
+	if err := os.WriteFile(configPath, []byte(initial), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Load (this absolutizes the relative file: paths in memory) ...
+	config, err := LoadConfigFromPath(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// ... sanity-check that load did absolutize as expected.
+	if khelm := config.Binaries.Get("khelm"); khelm == nil || !filepath.IsAbs(khelm.File) {
+		t.Fatalf("expected khelm.File to be absolute after load, got %q", mustFile(config, "khelm"))
+	}
+
+	// Simulate `--add`: append a new binary and save back to the same file.
+	config.Binaries = append(config.Binaries, &binary.LocalBinary{Name: "yq"})
+	if err := SaveConfig(config, configPath); err != nil {
+		t.Fatal(err)
+	}
+
+	// The on-disk file must still carry the original relative paths.
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(data)
+
+	if !strings.Contains(got, "file: jira\n") {
+		t.Errorf("expected jira-cli to keep relative 'file: jira', got:\n%s", got)
+	}
+	if !strings.Contains(got, "file: .kustomize/khelm.mgoltzsche.github.com/v2/chartrenderer/ChartRenderer") {
+		t.Errorf("expected khelm to keep its relative file path, got:\n%s", got)
+	}
+	if strings.Contains(got, tmpDir) {
+		t.Errorf("config should not contain absolute paths (%s), got:\n%s", tmpDir, got)
+	}
+
+	// In-memory state must be restored to absolute so the running process is
+	// unaffected by the save.
+	if khelm := config.Binaries.Get("khelm"); khelm == nil || !filepath.IsAbs(khelm.File) {
+		t.Errorf("expected khelm.File to remain absolute in memory after save, got %q", mustFile(config, "khelm"))
+	}
+
+	// Reloading must yield the same absolute path as before (proves the
+	// relative value still resolves against the config dir).
+	reloaded, err := LoadConfigFromPath(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(tmpDir, "jira")
+	if got := mustFile(reloaded, "github.com/ankitpokhrel/jira-cli"); got != want {
+		t.Errorf("reloaded jira file = %q, want %q", got, want)
+	}
+}
+
+// TestSaveConfig_KeepsRelativeFilePaths_NewFile covers the clean-save path
+// (no pre-existing file), where the binaries are marshaled from scratch.
+func TestSaveConfig_KeepsRelativeFilePaths_NewFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "b.yaml")
+
+	// Mimic in-memory state as produced after a load: an absolute File path
+	// pointing under the config dir.
+	config := &State{
+		Binaries: BinaryList{
+			&binary.LocalBinary{Name: "khelm", File: filepath.Join(tmpDir, "tools", "khelm")},
+		},
+	}
+
+	if err := SaveConfig(config, configPath); err != nil {
+		t.Fatal(err)
+	}
+
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(data)
+	if !strings.Contains(got, "file: tools/khelm") {
+		t.Errorf("expected relative 'file: tools/khelm', got:\n%s", got)
+	}
+	if strings.Contains(got, tmpDir) {
+		t.Errorf("config should not contain absolute paths (%s), got:\n%s", tmpDir, got)
+	}
+}
+
+// TestRelativizeFiles_LeavesOutsidePathsAbsolute ensures absolute File paths
+// that don't live under the config dir are preserved verbatim.
+func TestRelativizeFiles_LeavesOutsidePathsAbsolute(t *testing.T) {
+	outside := filepath.Join(string(filepath.Separator)+"opt", "bin", "tool")
+	config := &State{
+		Binaries: BinaryList{
+			&binary.LocalBinary{Name: "tool", File: outside},
+		},
+	}
+
+	restore := relativizeFiles(config, filepath.Join(string(filepath.Separator)+"home", "user", ".bin"))
+	if got := mustFile(config, "tool"); got != outside {
+		t.Errorf("outside path should stay absolute, got %q", got)
+	}
+	restore()
+	if got := mustFile(config, "tool"); got != outside {
+		t.Errorf("restore changed an untouched path, got %q", got)
+	}
+}
+
+func mustFile(s *State, name string) string {
+	if b := s.Binaries.Get(name); b != nil {
+		return b.File
+	}
+	return ""
+}

--- a/pkg/state/config_test.go
+++ b/pkg/state/config_test.go
@@ -81,11 +81,10 @@ func TestSaveConfig_KeepsRelativeFilePaths(t *testing.T) {
 	}
 }
 
-// TestSaveConfig_KeepsRelativeFilePaths_RelativeConfigPath covers the case
-// Copilot flagged: when configPath is relative, LoadConfigFromPath joins
-// `file:` into a still-relative path (e.g. ".bin/jira"), so the relativize on
-// save must not gate on filepath.IsAbs — otherwise the round-trip rewrites
-// "jira" to ".bin/jira".
+// TestSaveConfig_KeepsRelativeFilePaths_RelativeConfigPath covers a relative
+// configPath: LoadConfigFromPath joins `file:` into a still-relative path
+// (e.g. ".bin/jira"), so the relativize on save must not gate on
+// filepath.IsAbs — otherwise the round-trip rewrites "jira" to ".bin/jira".
 func TestSaveConfig_KeepsRelativeFilePaths_RelativeConfigPath(t *testing.T) {
 	tmpDir := t.TempDir()
 	binDir := filepath.Join(tmpDir, ".bin")


### PR DESCRIPTION
## Summary

Three fixes surfaced by an arm64 user running `b install` on a project with custom `file:` paths in `b.yaml`.

### 1. `b install --add` no longer rewrites relative `file:` paths to absolute
`LoadConfigFromPath` absolutizes relative `file:` values in memory so the running process has a real on-disk location. `SaveConfig` never reversed this, so any load→modify→save round-trip (which `--add` does) wrote absolute paths back into `b.yaml`. Added `relativizeFiles` (the inverse of the load-time join) called via `defer` in `SaveConfig`; in-memory state is restored to absolute afterwards. Absolute paths outside the config dir are left untouched. Covered by new round-trip tests.

### 2. Compact, named unsupported-platform error for renvsubst
`unsupported platform: linux/arm64` → `no linux/arm64 build for renvsubst`. The progress tracker replaces the row label with the error text, so naming the binary matters.

### 3. Clearer download-404 message
Dropped the confusing `8.20.0 not found ^^ 8.20.0` form (printed even when requested == latest). Now distinguishes a wrong version (`latest: ...`) from a missing platform asset (`not found for linux/arm64`), and includes the binary name.

## Test plan
- `go test ./...` passes
- New `pkg/state/config_test.go` reproduces the `--add` round-trip and asserts relative paths survive

🤖 Generated with [Claude Code](https://claude.com/claude-code)
