### PR TITLE
feat(update): address envs by their printed key; add scope flags (#166)

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,15 @@ b install github.com/org/infra@v2.0:/manifests/base/** .
 # Update all binaries and envs
 b update
 
+# Update a specific env — paste the key `b env status` prints, or a short handle
+b update github.com/org/infra
+b update git@github.com:org/infra#main
+b update infra#                          # short handle (the `#` marks it an env)
+
+# Update only envs (skip the toolchain) — or only binaries
+b update --envs-only
+b update --binaries-only
+
 # Update with merge strategy (three-way merge on local changes)
 b update --strategy=merge
 

--- a/docs/b/subcommands/update.mdx
+++ b/docs/b/subcommands/update.mdx
@@ -71,8 +71,10 @@ you to use the fuller key.
 
 If you type the plain https path of an SSH-keyed env (e.g. `github.com/org/infra`
 for an env keyed `git@github.com:org/infra`), `b` updates it as an ad-hoc
-**binary** and prints a hint pointing at the env — paste the key `b env status`
-prints, or append `#`, to target the env instead.
+**binary** and prints a hint pointing at the env. To target the env instead,
+paste the exact key `b env status` prints, or use a short handle (`org/infra#`) —
+appending `#` to the https path won't match, since the SSH key has no host
+segment.
 
 ### Scope: envs only / binaries only
 

--- a/docs/b/subcommands/update.mdx
+++ b/docs/b/subcommands/update.mdx
@@ -56,6 +56,24 @@ b update github.com/org/infra#
 > The `#` is safe unquoted as long as there is no space before it
 > (`name#label`, `name#`). A space before `#` starts a shell comment.
 
+With the `#` marker you can also use a **short handle** — the repo name, or
+`org/repo` — instead of the full key. `b` matches it against the trailing
+segments of your configured env keys:
+
+```bash
+# both target an env keyed git@github.com:org/infra#main
+b update infra#
+b update org/infra#
+```
+
+If a short handle matches more than one env, `b` lists the candidates and asks
+you to use the fuller key.
+
+If you type the plain https path of an SSH-keyed env (e.g. `github.com/org/infra`
+for an env keyed `git@github.com:org/infra`), `b` updates it as an ad-hoc
+**binary** and prints a hint pointing at the env — paste the key `b env status`
+prints, or append `#`, to target the env instead.
+
 ### Scope: envs only / binaries only
 
 Refresh vendored env content without touching the toolchain, or vice versa:

--- a/docs/b/subcommands/update.mdx
+++ b/docs/b/subcommands/update.mdx
@@ -34,6 +34,40 @@ Update a single binary to its latest version.
 b update jq
 ```
 
+### Update a specific env
+
+Pass the exact env key that `b env status` prints — including SSH (`git@…`) keys
+and `#label` refs. The key round-trips as-is:
+
+```bash
+b update github.com/org/infra
+b update git@github.com:org/infra#main
+```
+
+A ref like `github.com/org/infra` is a valid env key **and** a valid binary
+provider ref. When it is configured as an env, `b` resolves it to the env. To
+force env resolution explicitly — useful for label-less keys, or when the same
+ref exists as both a binary and an env — append a `#`:
+
+```bash
+b update github.com/org/infra#
+```
+
+> The `#` is safe unquoted as long as there is no space before it
+> (`name#label`, `name#`). A space before `#` starts a shell comment.
+
+### Scope: envs only / binaries only
+
+Refresh vendored env content without touching the toolchain, or vice versa:
+
+```bash
+# Sync every env, skip binaries
+b update --envs-only
+
+# Update every binary, skip env sync
+b update --binaries-only
+```
+
 ### Force an update
 
 Force an update even if the binary is already at the latest version. This is useful for re-installing a corrupted binary.
@@ -100,7 +134,8 @@ b update --rollback github.com/org/infra
 
 ### Group filtering
 
-Only update envs tagged with a specific group:
+Only update envs tagged with a specific group. Groups are an env-only concept,
+so `--group` implies `--envs-only` — binaries are left untouched:
 
 ```bash
 b update --group=dev
@@ -129,7 +164,9 @@ the full list of environment variables and examples.
 | `--strategy`      | Merge strategy for env updates: `replace`, `client`, or `merge` |
 | `--dry-run`       | Show what would change without writing files |
 | `--rollback`      | Rollback envs to their previous commit from lock |
-| `--group`         | Only update envs in this group |
+| `--group`         | Only update envs in this group (implies `--envs-only`) |
+| `--envs-only`     | Only update envs, skip binaries |
+| `--binaries-only` | Only update binaries, skip envs |
 | `-h`, `--help`    | help for update                           |
 
 ## Global Flags

--- a/docs/env-sync.mdx
+++ b/docs/env-sync.mdx
@@ -364,6 +364,29 @@ Check for upstream changes and local drift without syncing:
 b env status
 ```
 
+### Update a specific env
+
+Pass the exact key `b env status` prints — `https`, SSH (`git@…`), and `#label`
+forms all round-trip as-is:
+
+```bash
+b update github.com/org/infra
+b update git@github.com:org/infra#main
+```
+
+You can also use a **short handle** (the repo name, or `org/repo`) by appending
+a `#` marker; ambiguous handles list the candidates:
+
+```bash
+b update infra#
+b update org/infra#
+```
+
+To refresh vendored env content without bumping any binaries, scope the run with
+`--envs-only` (or `--group`, which is env-only); `--binaries-only` does the
+reverse. See [b update](/b/subcommands/update#update-a-specific-env) for the full
+addressing rules.
+
 ### Preview
 
 Test what a glob matches before adding it to config:
@@ -491,6 +514,7 @@ envs:
 ```
 
 ```bash
+# groups are env-only, so --group updates just these envs (no binaries)
 b update --group=dev
 ```
 

--- a/pkg/cli/update.go
+++ b/pkg/cli/update.go
@@ -48,6 +48,8 @@ type UpdateOptions struct {
 	Yes               bool                         // skip prompt confirmations (treat prompt as auto)
 	Rollback          bool                         // rollback to previous commit from lock
 	Group             string                       // only update envs in this group
+	EnvsOnly          bool                         // update envs only, skip binaries
+	BinariesOnly      bool                         // update binaries only, skip envs
 	stdinReader       io.Reader                    // overridden by tests; nil means os.Stdin
 	updateBinariesF   func([]*binary.Binary) error // overridden by tests; nil means o.updateBinaries
 }
@@ -70,8 +72,20 @@ func NewUpdateCmd(shared *SharedOptions) *cobra.Command {
 			# Update specific binary
 			b update jq
 
-			# Update specific env
+			# Update specific env (paste the key 'b env status' prints)
 			b update github.com/org/infra
+			b update git@github.com:org/infra#main
+
+			# Force env resolution for a key that is also a valid binary ref
+			# by appending '#' (works for any env, incl. label-less ones)
+			b update github.com/org/infra#
+
+			# Update only envs (skip the toolchain), optionally by group
+			b update --envs-only
+			b update --group dev
+
+			# Update only binaries (skip env sync)
+			b update --binaries-only
 
 			# Force update (overwrite existing)
 			b update --force kubectl
@@ -99,7 +113,9 @@ func NewUpdateCmd(shared *SharedOptions) *cobra.Command {
 	cmd.Flags().BoolVar(&o.PlanJSON, "plan-json", false, "Emit a machine-readable plan as JSON (implies --dry-run)")
 	cmd.Flags().BoolVarP(&o.Yes, "yes", "y", false, "Skip prompt confirmation (treat prompt as auto)")
 	cmd.Flags().BoolVar(&o.Rollback, "rollback", false, "Rollback envs to previous commit from lock")
-	cmd.Flags().StringVar(&o.Group, "group", "", "Only update envs in this group")
+	cmd.Flags().StringVar(&o.Group, "group", "", "Only update envs in this group (implies --envs-only)")
+	cmd.Flags().BoolVar(&o.EnvsOnly, "envs-only", false, "Only update envs, skip binaries")
+	cmd.Flags().BoolVar(&o.BinariesOnly, "binaries-only", false, "Only update binaries, skip envs")
 
 	return cmd
 }
@@ -125,23 +141,15 @@ func (o *UpdateOptions) Complete(args []string) error {
 
 	o.specifiedArgs = args
 
-	// Resolve specified args (binaries or env refs) and store them
+	// Resolve specified args (binaries or env refs) and store them.
 	for _, arg := range args {
-		name, version := parseBinaryArg(arg)
-
-		// Check if it's an env ref
-		if o.Config != nil && o.Config.Envs.Get(name) != nil {
-			o.specifiedEnvRefs = append(o.specifiedEnvRefs, name)
+		envKey, b, err := o.resolveUpdateArg(arg)
+		if err != nil {
+			return err
+		}
+		if envKey != "" {
+			o.specifiedEnvRefs = append(o.specifiedEnvRefs, envKey)
 			continue
-		}
-
-		// Resolve binary once and keep the reference
-		b, ok := o.GetBinary(name)
-		if !ok {
-			return fmt.Errorf("unknown binary or env: %s", name)
-		}
-		if version != "" {
-			b.Version = version
 		}
 		o.specifiedBinaries = append(o.specifiedBinaries, b)
 	}
@@ -149,8 +157,185 @@ func (o *UpdateOptions) Complete(args []string) error {
 	return nil
 }
 
+// resolveUpdateArg maps a single CLI arg to either an env (returns its config
+// key) or a binary (returns the resolved *binary.Binary). Exactly one of the
+// two is non-empty on success.
+//
+// The arg addresses two namespaces (binaries and envs) whose grammars overlap,
+// so resolution is driven by config membership and an env marker rather than by
+// guessing from shape (issue #166):
+//
+//	docker:// / oci:// / go://   → always a binary ('#' there is a path/module
+//	                               char, never an env label)
+//	local path or contains '#'   → env marker: resolve as env, error if no such
+//	                               env (the user was explicit)
+//	otherwise                    → env-exact first (so the literal key printed by
+//	                               `b env status` round-trips, incl. SSH `git@…`
+//	                               keys whose '@' the binary parser would split),
+//	                               then binary.
+func (o *UpdateOptions) resolveUpdateArg(arg string) (envKey string, b *binary.Binary, err error) {
+	// Env marker: a local path, or a '#' outside a binary-only protocol.
+	if !hasBinaryProto(arg) && (isLocalRefPath(arg) || strings.Contains(arg, "#")) {
+		key, ok := o.matchEnv(arg)
+		if !ok {
+			return "", nil, fmt.Errorf("unknown env: %s", arg)
+		}
+		return key, nil, nil
+	}
+
+	// No marker: try envs by exact/canonical key before falling into binary
+	// space — otherwise a ref like github.com/org/infra that is an env would be
+	// hijacked by the github provider convention and fail as a binary.
+	if key, ok := o.matchEnv(arg); ok {
+		return key, nil, nil
+	}
+
+	name, version := parseBinaryArg(arg)
+	bin, ok := o.GetBinary(name)
+	if !ok {
+		return "", nil, o.unknownArgError(arg)
+	}
+	if version != "" {
+		bin.Version = version
+	}
+	// If this resolved to an ad-hoc provider binary (not in config) while a
+	// configured env targets the same repo, the user probably meant the env
+	// (e.g. typed the https path of an SSH-keyed env — issue #166). The ad-hoc
+	// binary update is still valid, so just say so rather than refuse.
+	if !o.isConfigBinary(name) {
+		if sug := o.suggestEnv(arg); sug != "" {
+			fmt.Fprintf(o.IO.ErrOut,
+				"  note: updating %q as a binary; env %q targets the same repo — pass %q (or append '#') to update the env\n",
+				name, sug, sug)
+		}
+	}
+	return "", bin, nil
+}
+
+// isConfigBinary reports whether name is a known binary — a preset or an entry
+// in b.yaml's binaries — as opposed to an ad-hoc provider ref synthesized on
+// the fly.
+func (o *UpdateOptions) isConfigBinary(name string) bool {
+	if _, ok := o.lookup[name]; ok {
+		return true
+	}
+	if o.Config == nil {
+		return false
+	}
+	for _, lb := range o.Config.Binaries {
+		if lb.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+// matchEnv resolves arg to a configured env key, trying the literal string
+// first (so the exact key `b env status` prints round-trips) and then a
+// canonical form with any trailing version stripped and label normalized.
+func (o *UpdateOptions) matchEnv(arg string) (string, bool) {
+	if o.Config == nil {
+		return "", false
+	}
+	if e := o.Config.Envs.Get(arg); e != nil {
+		return e.Key, true
+	}
+	if key := canonicalEnvKey(arg); key != arg {
+		if e := o.Config.Envs.Get(key); e != nil {
+			return e.Key, true
+		}
+	}
+	return "", false
+}
+
+// unknownArgError builds the not-found error, adding a "did you mean env …"
+// hint when a configured env points at the same repo via a different ref form
+// (e.g. the user typed the https path for an SSH-keyed env — issue #166).
+func (o *UpdateOptions) unknownArgError(arg string) error {
+	if sug := o.suggestEnv(arg); sug != "" {
+		return fmt.Errorf("unknown binary or env: %s (did you mean env %q? append '#' to force env)", arg, sug)
+	}
+	return fmt.Errorf("unknown binary or env: %s", arg)
+}
+
+// suggestEnv returns a configured env key that shares the same trailing
+// org/repo path as arg, or "" if none. Used only to enrich the not-found
+// error — it never changes resolution.
+func (o *UpdateOptions) suggestEnv(arg string) string {
+	if o.Config == nil {
+		return ""
+	}
+	want := repoTail(gitcache.RefBase(arg))
+	if want == "" {
+		return ""
+	}
+	for _, e := range o.Config.Envs {
+		if repoTail(gitcache.RefBase(e.Key)) == want {
+			return e.Key
+		}
+	}
+	return ""
+}
+
+// repoTail returns the "org/repo" tail of a git ref base, lowercased and
+// without a .git suffix, so https and SSH forms of the same repo compare equal.
+func repoTail(base string) string {
+	base = strings.TrimSuffix(base, ".git")
+	// Drop an SSH "user@host:" or "host:" prefix and any scheme.
+	if i := strings.LastIndex(base, "://"); i >= 0 {
+		base = base[i+3:]
+	}
+	if i := strings.Index(base, ":"); i >= 0 && !strings.Contains(base[:i], "/") {
+		base = base[i+1:]
+	}
+	parts := strings.Split(strings.Trim(base, "/"), "/")
+	if len(parts) < 2 {
+		return ""
+	}
+	return strings.ToLower(strings.Join(parts[len(parts)-2:], "/"))
+}
+
+// canonicalEnvKey normalizes a ref to the form used as an env map key: the ref
+// base (version stripped) plus "#label" when a label is present. Local paths
+// are returned as-is (their '#'/'@' are literal path characters).
+func canonicalEnvKey(arg string) string {
+	base := gitcache.RefBase(arg)
+	if label := gitcache.RefLabel(arg); label != "" {
+		return base + "#" + label
+	}
+	return base
+}
+
+// hasBinaryProto reports whether s carries a protocol that only binaries use,
+// where a '#' is a path/module character rather than an env label.
+func hasBinaryProto(s string) bool {
+	return strings.HasPrefix(s, "docker://") ||
+		strings.HasPrefix(s, "oci://") ||
+		strings.HasPrefix(s, "go://")
+}
+
+// isLocalRefPath reports whether s is a local filesystem ref (an env source),
+// matching gitcache's own local-path detection.
+func isLocalRefPath(s string) bool {
+	return strings.HasPrefix(s, "/") ||
+		strings.HasPrefix(s, "./") ||
+		strings.HasPrefix(s, "../")
+}
+
 // Validate checks if the update operation is valid
 func (o *UpdateOptions) Validate() error {
+	// Scope flags select which namespace the "update all" form touches; they
+	// are contradictory together and meaningless once specific args narrow the
+	// scope already.
+	if o.EnvsOnly && o.BinariesOnly {
+		return fmt.Errorf("--envs-only and --binaries-only are mutually exclusive")
+	}
+	if o.BinariesOnly && o.Group != "" {
+		return fmt.Errorf("--group filters envs and cannot be combined with --binaries-only")
+	}
+	if (o.EnvsOnly || o.BinariesOnly) && len(o.specifiedArgs) > 0 {
+		return fmt.Errorf("--envs-only/--binaries-only apply to 'b update' with no arguments; remove them when naming binaries or envs explicitly")
+	}
 	if o.Strategy != "" {
 		switch o.Strategy {
 		case env.StrategyReplace, env.StrategyClient, env.StrategyMerge:
@@ -202,24 +387,34 @@ func (o *UpdateOptions) effectiveDryRun() bool {
 
 // runAll updates all binaries and envs from config.
 func (o *UpdateOptions) runAll() error {
+	// Scope which namespaces this run touches. `group` is an env-only concept,
+	// so --group implies env scope (binaries have no groups — issue #166).
+	doBinaries := !o.EnvsOnly && o.Group == ""
+	doEnvs := !o.BinariesOnly
+
 	// Update binaries — but NOT in plan-json mode, where binary
 	// progress output would corrupt the JSON document on stdout.
-	//.
-	binariesToUpdate := o.GetBinariesFromConfig()
-	if len(binariesToUpdate) > 0 && !o.PlanJSON {
-		if err := o.callUpdateBinaries(binariesToUpdate); err != nil {
-			return err
+	var binariesToUpdate []*binary.Binary
+	if doBinaries {
+		binariesToUpdate = o.GetBinariesFromConfig()
+		if len(binariesToUpdate) > 0 && !o.PlanJSON {
+			if err := o.callUpdateBinaries(binariesToUpdate); err != nil {
+				return err
+			}
 		}
 	}
 
 	// Update envs
-	if o.Config != nil && len(o.Config.Envs) > 0 {
+	hasEnvs := o.Config != nil && len(o.Config.Envs) > 0
+	if doEnvs && hasEnvs {
 		if err := o.updateEnvs(nil); err != nil {
 			return err
 		}
 	}
 
-	if len(binariesToUpdate) == 0 && (o.Config == nil || len(o.Config.Envs) == 0) {
+	nothingBinaries := !doBinaries || len(binariesToUpdate) == 0
+	nothingEnvs := !doEnvs || !hasEnvs
+	if nothingBinaries && nothingEnvs {
 		// In plan-json mode the human-readable line would corrupt
 		// the JSON output. Emit an empty array instead so consumers
 		// always get valid JSON.

--- a/pkg/cli/update.go
+++ b/pkg/cli/update.go
@@ -214,11 +214,24 @@ func (o *UpdateOptions) resolveUpdateArg(arg string) (envKey string, b *binary.B
 	if !o.isConfigBinary(name) {
 		if sug := o.suggestEnv(arg); sug != "" {
 			fmt.Fprintf(o.IO.ErrOut,
-				"  note: updating %q as a binary; env %q targets the same repo — pass %q (or append '#') to update the env\n",
-				name, sug, sug)
+				"  note: updating %q as a binary; env %q targets the same repo — to update that env run: %s\n",
+				name, sug, envUpdateHint(sug))
 		}
 	}
 	return "", bin, nil
+}
+
+// envUpdateHint returns a copy-pasteable command that resolves to the env keyed
+// `key`. It suggests the exact key (always works) and, when the repo tail is
+// unambiguous to derive, a short-handle alternative. It deliberately does NOT
+// suggest "append '#' to what you typed" — for an https arg pointing at an
+// SSH-keyed env, that form does not match (issue #166 review).
+func envUpdateHint(key string) string {
+	hint := fmt.Sprintf("b update %q", key)
+	if short := repoTail(key); short != "" {
+		hint += fmt.Sprintf(" (or short: b update %s#)", short)
+	}
+	return hint
 }
 
 // isConfigBinary reports whether name is a known binary — a preset or an entry
@@ -276,13 +289,13 @@ func (o *UpdateOptions) matchEnv(arg string, allowShort bool) (string, bool, err
 // Returns (key, nil) on a unique hit, or ("", candidates) when zero or
 // multiple envs match so the caller can report ambiguity.
 func (o *UpdateOptions) matchEnvShort(arg string) (string, []string) {
-	want := cleanRepoPath(gitcache.RefBase(arg))
-	if len(want) == 0 || want[0] == "" {
+	want := gitcache.RepoPath(arg)
+	if len(want) == 0 {
 		return "", nil
 	}
 	var matches []string
 	for _, e := range o.Config.Envs {
-		if pathHasSuffix(cleanRepoPath(gitcache.RefBase(e.Key)), want) {
+		if pathHasSuffix(gitcache.RepoPath(e.Key), want) {
 			matches = append(matches, e.Key)
 		}
 	}
@@ -311,7 +324,7 @@ func pathHasSuffix(full, suf []string) bool {
 // (e.g. the user typed the https path for an SSH-keyed env — issue #166).
 func (o *UpdateOptions) unknownArgError(arg string) error {
 	if sug := o.suggestEnv(arg); sug != "" {
-		return fmt.Errorf("unknown binary or env: %s (did you mean env %q? append '#' to force env)", arg, sug)
+		return fmt.Errorf("unknown binary or env: %s — did you mean env %q? run: %s", arg, sug, envUpdateHint(sug))
 	}
 	return fmt.Errorf("unknown binary or env: %s", arg)
 }
@@ -323,41 +336,27 @@ func (o *UpdateOptions) suggestEnv(arg string) string {
 	if o.Config == nil {
 		return ""
 	}
-	want := repoTail(gitcache.RefBase(arg))
+	want := repoTail(arg)
 	if want == "" {
 		return ""
 	}
 	for _, e := range o.Config.Envs {
-		if repoTail(gitcache.RefBase(e.Key)) == want {
+		if repoTail(e.Key) == want {
 			return e.Key
 		}
 	}
 	return ""
 }
 
-// repoTail returns the "org/repo" tail of a git ref base, lowercased and
-// without a .git suffix, so https and SSH forms of the same repo compare equal.
-func repoTail(base string) string {
-	parts := cleanRepoPath(base)
-	if len(parts) < 2 || parts[0] == "" {
+// repoTail returns the "org/repo" tail of a git ref, lowercased and transport-
+// independent, so https and SSH forms of the same repo compare equal. Returns
+// "" when the ref has fewer than two path segments.
+func repoTail(ref string) string {
+	parts := gitcache.RepoPath(ref)
+	if len(parts) < 2 {
 		return ""
 	}
 	return strings.ToLower(strings.Join(parts[len(parts)-2:], "/"))
-}
-
-// cleanRepoPath strips a .git suffix, any scheme, and an SSH "user@host:" /
-// "host:" prefix from a git ref base, returning the remaining path split into
-// segments (e.g. "git@github.com:org/repo.git" → ["org","repo"]). Transport is
-// dropped so https and SSH forms of the same repo yield identical segments.
-func cleanRepoPath(base string) []string {
-	base = strings.TrimSuffix(base, ".git")
-	if i := strings.LastIndex(base, "://"); i >= 0 {
-		base = base[i+3:]
-	}
-	if i := strings.Index(base, ":"); i >= 0 && !strings.Contains(base[:i], "/") {
-		base = base[i+1:]
-	}
-	return strings.Split(strings.Trim(base, "/"), "/")
 }
 
 // canonicalEnvKey normalizes a ref to the form used as an env map key: the ref
@@ -483,7 +482,11 @@ func (o *UpdateOptions) runAll() error {
 		}
 	}
 
-	nothingBinaries := !doBinaries || len(binariesToUpdate) == 0
+	// In plan-json mode binaries never produce output, so they count as
+	// "nothing" for the empty-array fallback — otherwise a binaries-only project
+	// run with --plan-json would print no JSON at all (the opposite of the
+	// "consumers always get valid JSON" contract).
+	nothingBinaries := !doBinaries || len(binariesToUpdate) == 0 || o.PlanJSON
 	nothingEnvs := !doEnvs || !hasEnvs
 	if nothingBinaries && nothingEnvs {
 		// In plan-json mode the human-readable line would corrupt

--- a/pkg/cli/update.go
+++ b/pkg/cli/update.go
@@ -174,9 +174,14 @@ func (o *UpdateOptions) Complete(args []string) error {
 //	                               keys whose '@' the binary parser would split),
 //	                               then binary.
 func (o *UpdateOptions) resolveUpdateArg(arg string) (envKey string, b *binary.Binary, err error) {
-	// Env marker: a local path, or a '#' outside a binary-only protocol.
+	// Env marker: a local path, or a '#' outside a binary-only protocol. The
+	// user was explicit, so short handles (repo basename / org/repo tail) are
+	// allowed in addition to exact/canonical keys.
 	if !hasBinaryProto(arg) && (isLocalRefPath(arg) || strings.Contains(arg, "#")) {
-		key, ok := o.matchEnv(arg)
+		key, ok, mErr := o.matchEnv(arg, true)
+		if mErr != nil {
+			return "", nil, mErr
+		}
 		if !ok {
 			return "", nil, fmt.Errorf("unknown env: %s", arg)
 		}
@@ -185,8 +190,12 @@ func (o *UpdateOptions) resolveUpdateArg(arg string) (envKey string, b *binary.B
 
 	// No marker: try envs by exact/canonical key before falling into binary
 	// space — otherwise a ref like github.com/org/infra that is an env would be
-	// hijacked by the github provider convention and fail as a binary.
-	if key, ok := o.matchEnv(arg); ok {
+	// hijacked by the github provider convention and fail as a binary. Short
+	// handles are NOT allowed here so a bare name can never shadow a binary;
+	// they require the explicit '#'/path marker handled above.
+	if key, ok, mErr := o.matchEnv(arg, false); mErr != nil {
+		return "", nil, mErr
+	} else if ok {
 		return key, nil, nil
 	}
 
@@ -230,22 +239,71 @@ func (o *UpdateOptions) isConfigBinary(name string) bool {
 	return false
 }
 
-// matchEnv resolves arg to a configured env key, trying the literal string
-// first (so the exact key `b env status` prints round-trips) and then a
-// canonical form with any trailing version stripped and label normalized.
-func (o *UpdateOptions) matchEnv(arg string) (string, bool) {
+// matchEnv resolves arg to a configured env key. It tries, in order: the
+// literal string (so the exact key `b env status` prints round-trips), a
+// canonical form with any trailing version stripped and label normalized, and
+// — only when allowShort is set — a short handle that suffix-matches an env's
+// repo path (e.g. "lok8s" or "org/lok8s" → "git@github.com:org/lok8s#main").
+// An ambiguous short handle returns an error listing the candidate keys.
+func (o *UpdateOptions) matchEnv(arg string, allowShort bool) (string, bool, error) {
 	if o.Config == nil {
-		return "", false
+		return "", false, nil
 	}
 	if e := o.Config.Envs.Get(arg); e != nil {
-		return e.Key, true
+		return e.Key, true, nil
 	}
 	if key := canonicalEnvKey(arg); key != arg {
 		if e := o.Config.Envs.Get(key); e != nil {
-			return e.Key, true
+			return e.Key, true, nil
 		}
 	}
-	return "", false
+	if allowShort {
+		key, candidates := o.matchEnvShort(arg)
+		if key != "" {
+			return key, true, nil
+		}
+		if len(candidates) > 1 {
+			return "", false, fmt.Errorf("ambiguous env %q matches %d keys: %s — use the full key",
+				arg, len(candidates), strings.Join(candidates, ", "))
+		}
+	}
+	return "", false, nil
+}
+
+// matchEnvShort matches arg as a short handle against configured env keys: the
+// arg's cleaned repo path must be a trailing segment-suffix of an env's. So
+// "lok8s" or "org/lok8s" both reach an env keyed "git@github.com:org/lok8s".
+// Returns (key, nil) on a unique hit, or ("", candidates) when zero or
+// multiple envs match so the caller can report ambiguity.
+func (o *UpdateOptions) matchEnvShort(arg string) (string, []string) {
+	want := cleanRepoPath(gitcache.RefBase(arg))
+	if len(want) == 0 || want[0] == "" {
+		return "", nil
+	}
+	var matches []string
+	for _, e := range o.Config.Envs {
+		if pathHasSuffix(cleanRepoPath(gitcache.RefBase(e.Key)), want) {
+			matches = append(matches, e.Key)
+		}
+	}
+	if len(matches) == 1 {
+		return matches[0], nil
+	}
+	return "", matches
+}
+
+// pathHasSuffix reports whether suf is a trailing whole-segment suffix of full
+// (case-insensitive), e.g. ["org","repo"] is a suffix of ["host","org","repo"].
+func pathHasSuffix(full, suf []string) bool {
+	if len(suf) == 0 || len(suf) > len(full) {
+		return false
+	}
+	for i := 1; i <= len(suf); i++ {
+		if !strings.EqualFold(full[len(full)-i], suf[len(suf)-i]) {
+			return false
+		}
+	}
+	return true
 }
 
 // unknownArgError builds the not-found error, adding a "did you mean env …"
@@ -280,19 +338,26 @@ func (o *UpdateOptions) suggestEnv(arg string) string {
 // repoTail returns the "org/repo" tail of a git ref base, lowercased and
 // without a .git suffix, so https and SSH forms of the same repo compare equal.
 func repoTail(base string) string {
+	parts := cleanRepoPath(base)
+	if len(parts) < 2 || parts[0] == "" {
+		return ""
+	}
+	return strings.ToLower(strings.Join(parts[len(parts)-2:], "/"))
+}
+
+// cleanRepoPath strips a .git suffix, any scheme, and an SSH "user@host:" /
+// "host:" prefix from a git ref base, returning the remaining path split into
+// segments (e.g. "git@github.com:org/repo.git" → ["org","repo"]). Transport is
+// dropped so https and SSH forms of the same repo yield identical segments.
+func cleanRepoPath(base string) []string {
 	base = strings.TrimSuffix(base, ".git")
-	// Drop an SSH "user@host:" or "host:" prefix and any scheme.
 	if i := strings.LastIndex(base, "://"); i >= 0 {
 		base = base[i+3:]
 	}
 	if i := strings.Index(base, ":"); i >= 0 && !strings.Contains(base[:i], "/") {
 		base = base[i+1:]
 	}
-	parts := strings.Split(strings.Trim(base, "/"), "/")
-	if len(parts) < 2 {
-		return ""
-	}
-	return strings.ToLower(strings.Join(parts[len(parts)-2:], "/"))
+	return strings.Split(strings.Trim(base, "/"), "/")
 }
 
 // canonicalEnvKey normalizes a ref to the form used as an env map key: the ref
@@ -333,8 +398,14 @@ func (o *UpdateOptions) Validate() error {
 	if o.BinariesOnly && o.Group != "" {
 		return fmt.Errorf("--group filters envs and cannot be combined with --binaries-only")
 	}
-	if (o.EnvsOnly || o.BinariesOnly) && len(o.specifiedArgs) > 0 {
-		return fmt.Errorf("--envs-only/--binaries-only apply to 'b update' with no arguments; remove them when naming binaries or envs explicitly")
+	if o.BinariesOnly && o.PlanJSON {
+		return fmt.Errorf("--plan-json describes env changes only and has no effect with --binaries-only")
+	}
+	// --group is env-only, so naming binaries/envs explicitly contradicts it the
+	// same way the scope flags do — and a non-matching --group would otherwise
+	// silently drop the named env to a no-op.
+	if (o.EnvsOnly || o.BinariesOnly || o.Group != "") && len(o.specifiedArgs) > 0 {
+		return fmt.Errorf("--group/--envs-only/--binaries-only apply to 'b update' with no arguments; remove them when naming binaries or envs explicitly")
 	}
 	if o.Strategy != "" {
 		switch o.Strategy {

--- a/pkg/cli/update.go
+++ b/pkg/cli/update.go
@@ -215,23 +215,39 @@ func (o *UpdateOptions) resolveUpdateArg(arg string) (envKey string, b *binary.B
 		if sug := o.suggestEnv(arg); sug != "" {
 			fmt.Fprintf(o.IO.ErrOut,
 				"  note: updating %q as a binary; env %q targets the same repo — to update that env run: %s\n",
-				name, sug, envUpdateHint(sug))
+				name, sug, o.envUpdateHint(sug))
 		}
 	}
 	return "", bin, nil
 }
 
 // envUpdateHint returns a copy-pasteable command that resolves to the env keyed
-// `key`. It suggests the exact key (always works) and, when the repo tail is
-// unambiguous to derive, a short-handle alternative. It deliberately does NOT
-// suggest "append '#' to what you typed" — for an https arg pointing at an
-// SSH-keyed env, that form does not match (issue #166 review).
-func envUpdateHint(key string) string {
+// `key`. It always suggests the exact key (which round-trips), and adds a short
+// handle only when that handle is unambiguous — otherwise the short form would
+// itself fail to resolve. It deliberately does NOT suggest "append '#' to what
+// you typed" — for an https arg pointing at an SSH-keyed env, that form does not
+// match (issue #166 review).
+func (o *UpdateOptions) envUpdateHint(key string) string {
 	hint := fmt.Sprintf("b update %q", key)
-	if short := repoTail(key); short != "" {
+	if short := repoTail(key); short != "" && o.shortHandleUnique(short) {
 		hint += fmt.Sprintf(" (or short: b update %s#)", short)
 	}
 	return hint
+}
+
+// shortHandleUnique reports whether exactly one configured env has the given
+// "org/repo" tail — i.e. whether `<tail>#` would resolve unambiguously.
+func (o *UpdateOptions) shortHandleUnique(tail string) bool {
+	if o.Config == nil {
+		return false
+	}
+	n := 0
+	for _, e := range o.Config.Envs {
+		if repoTail(e.Key) == tail {
+			n++
+		}
+	}
+	return n == 1
 }
 
 // isConfigBinary reports whether name is a known binary — a preset or an entry
@@ -324,7 +340,7 @@ func pathHasSuffix(full, suf []string) bool {
 // (e.g. the user typed the https path for an SSH-keyed env — issue #166).
 func (o *UpdateOptions) unknownArgError(arg string) error {
 	if sug := o.suggestEnv(arg); sug != "" {
-		return fmt.Errorf("unknown binary or env: %s — did you mean env %q? run: %s", arg, sug, envUpdateHint(sug))
+		return fmt.Errorf("unknown binary or env: %s — did you mean env %q? run: %s", arg, sug, o.envUpdateHint(sug))
 	}
 	return fmt.Errorf("unknown binary or env: %s", arg)
 }

--- a/pkg/cli/update.go
+++ b/pkg/cli/update.go
@@ -212,10 +212,8 @@ func (o *UpdateOptions) resolveUpdateArg(arg string) (envKey string, b *binary.B
 	// (e.g. typed the https path of an SSH-keyed env — issue #166). The ad-hoc
 	// binary update is still valid, so just say so rather than refuse.
 	if !o.isConfigBinary(name) {
-		if sug := o.suggestEnv(arg); sug != "" {
-			fmt.Fprintf(o.IO.ErrOut,
-				"  note: updating %q as a binary; env %q targets the same repo — to update that env run: %s\n",
-				name, sug, o.envUpdateHint(sug))
+		if hint := o.envHint(arg); hint != "" {
+			fmt.Fprintf(o.IO.ErrOut, "  note: updating %q as a binary; %s\n", name, hint)
 		}
 	}
 	return "", bin, nil
@@ -339,29 +337,49 @@ func pathHasSuffix(full, suf []string) bool {
 // hint when a configured env points at the same repo via a different ref form
 // (e.g. the user typed the https path for an SSH-keyed env — issue #166).
 func (o *UpdateOptions) unknownArgError(arg string) error {
-	if sug := o.suggestEnv(arg); sug != "" {
-		return fmt.Errorf("unknown binary or env: %s — did you mean env %q? run: %s", arg, sug, o.envUpdateHint(sug))
+	if hint := o.envHint(arg); hint != "" {
+		return fmt.Errorf("unknown binary or env: %s — did you mean %s", arg, hint)
 	}
 	return fmt.Errorf("unknown binary or env: %s", arg)
 }
 
-// suggestEnv returns a configured env key that shares the same trailing
-// org/repo path as arg, or "" if none. Used only to enrich the not-found
-// error — it never changes resolution.
-func (o *UpdateOptions) suggestEnv(arg string) string {
+// suggestEnvs returns all configured env keys that share arg's trailing
+// org/repo path (transport-independent), so callers can hint at the env(s) the
+// user may have meant. Empty when none match. Used only to enrich messages —
+// it never changes resolution.
+func (o *UpdateOptions) suggestEnvs(arg string) []string {
 	if o.Config == nil {
-		return ""
+		return nil
 	}
 	want := repoTail(arg)
 	if want == "" {
-		return ""
+		return nil
 	}
+	var keys []string
 	for _, e := range o.Config.Envs {
 		if repoTail(e.Key) == want {
-			return e.Key
+			keys = append(keys, e.Key)
 		}
 	}
-	return ""
+	return keys
+}
+
+// envHint builds a "did you mean env" clause for the env(s) matching arg, or ""
+// when none match. A single match names the key with a copy-paste command; when
+// several envs share the same repo tail (e.g. github + gitlab mirrors) it lists
+// the candidates instead of arbitrarily picking the first — pointing at the
+// wrong key would be misleading (issue #166 review).
+func (o *UpdateOptions) envHint(arg string) string {
+	keys := o.suggestEnvs(arg)
+	switch len(keys) {
+	case 0:
+		return ""
+	case 1:
+		return fmt.Sprintf("env %q targets the same repo — to update it run: %s", keys[0], o.envUpdateHint(keys[0]))
+	default:
+		return fmt.Sprintf("%d envs target the same repo (%s) — pass the exact key to update one",
+			len(keys), strings.Join(keys, ", "))
+	}
 }
 
 // repoTail returns the "org/repo" tail of a git ref, lowercased and transport-

--- a/pkg/cli/update.go
+++ b/pkg/cli/update.go
@@ -404,12 +404,16 @@ func canonicalEnvKey(arg string) string {
 	return base
 }
 
-// hasBinaryProto reports whether s carries a protocol that only binaries use,
-// where a '#' is a path/module character rather than an env label.
+// hasBinaryProto reports whether s carries a protocol for which a '#' must NOT
+// be treated as an env-label marker. docker:// / oci:// / go:// are binary-only.
+// git:// is ambiguous (a git-sourced binary's in-repo file path may legally
+// contain '#', e.g. git://repo:bin/we#rd), so we exclude it from the marker
+// rule too; git:// envs are still addressable by their exact/canonical key.
 func hasBinaryProto(s string) bool {
 	return strings.HasPrefix(s, "docker://") ||
 		strings.HasPrefix(s, "oci://") ||
-		strings.HasPrefix(s, "go://")
+		strings.HasPrefix(s, "go://") ||
+		strings.HasPrefix(s, "git://")
 }
 
 // isLocalRefPath reports whether s is a local filesystem ref (an env source),

--- a/pkg/cli/update_envaddr_test.go
+++ b/pkg/cli/update_envaddr_test.go
@@ -257,6 +257,27 @@ func TestResolveArg_HttpsPathForSSHEnv_HintsEnv(t *testing.T) {
 	}
 }
 
+// When several configured envs share the same repo tail, the ad-hoc-binary note
+// must list all candidates rather than arbitrarily naming the first, and must
+// not suggest an ambiguous short handle (Copilot round-3).
+func TestResolveArg_HttpsPathForSSHEnv_HintsAllOnAmbiguousTail(t *testing.T) {
+	o, errBuf := envAddrOpts(t, "git@github.com:org/infra#a", "gitlab.com/org/infra#b")
+
+	if err := o.Complete([]string{"github.com/org/infra"}); err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+	if len(o.specifiedBinaries) != 1 {
+		t.Fatalf("expected ad-hoc binary resolution, got %d", len(o.specifiedBinaries))
+	}
+	note := errBuf.String()
+	if !strings.Contains(note, "git@github.com:org/infra#a") || !strings.Contains(note, "gitlab.com/org/infra#b") {
+		t.Errorf("note should list both candidate envs, got: %q", note)
+	}
+	if strings.Contains(note, "or short") {
+		t.Errorf("note must not suggest an ambiguous short handle, got: %q", note)
+	}
+}
+
 // A '#' inside a docker:// in-container path is a path character, not an env
 // label — the ref must stay in binary space.
 func TestResolveArg_DockerPathHash_StaysBinary(t *testing.T) {

--- a/pkg/cli/update_envaddr_test.go
+++ b/pkg/cli/update_envaddr_test.go
@@ -294,6 +294,22 @@ func TestResolveArg_DockerPathHash_StaysBinary(t *testing.T) {
 	}
 }
 
+// A '#' inside a git:// binary ref's in-repo file path is a path character, not
+// an env-label marker — the ref must resolve as a binary (Copilot round-3).
+func TestResolveArg_GitProtoPathHash_StaysBinary(t *testing.T) {
+	o, _ := envAddrOpts(t) // no envs
+
+	if err := o.Complete([]string{"git://github.com/org/repo:bin/we#rd"}); err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+	if len(o.specifiedEnvRefs) != 0 {
+		t.Errorf("git:// binary ref must not resolve as env, got %d", len(o.specifiedEnvRefs))
+	}
+	if len(o.specifiedBinaries) != 1 {
+		t.Errorf("expected 1 binary, got %d", len(o.specifiedBinaries))
+	}
+}
+
 // repoTail folds https and SSH forms of the same repo to one comparable tail.
 func TestRepoTail(t *testing.T) {
 	cases := map[string]string{

--- a/pkg/cli/update_envaddr_test.go
+++ b/pkg/cli/update_envaddr_test.go
@@ -88,6 +88,62 @@ func TestResolveArg_EnvMarkerNoMatch_Errors(t *testing.T) {
 	}
 }
 
+// A short handle ('#'-marked) resolves to an env by repo basename or org/repo
+// tail — even an SSH-keyed env with a label. Closes issue #166's "short handle"
+// gap (Gemini review #1).
+func TestResolveArg_ShortHandle(t *testing.T) {
+	cases := []struct{ name, arg, want string }{
+		{"basename", "lok8s#", "git@github.com:kernpilot/lok8s#main"},
+		{"orgRepoTail", "kernpilot/lok8s#", "git@github.com:kernpilot/lok8s#main"},
+		{"labelledHttps", "github.com/org/infra#", "github.com/org/infra#prod"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			o, _ := envAddrOpts(t, "git@github.com:kernpilot/lok8s#main", "github.com/org/infra#prod")
+			if err := o.Complete([]string{tc.arg}); err != nil {
+				t.Fatalf("Complete(%q): %v", tc.arg, err)
+			}
+			if len(o.specifiedBinaries) != 0 {
+				t.Errorf("%q must not resolve to a binary", tc.arg)
+			}
+			if len(o.specifiedEnvRefs) != 1 || o.specifiedEnvRefs[0] != tc.want {
+				t.Errorf("%q → env refs %v, want [%s]", tc.arg, o.specifiedEnvRefs, tc.want)
+			}
+		})
+	}
+}
+
+// An ambiguous short handle (matching two envs) errors with the candidates,
+// rather than silently picking one.
+func TestResolveArg_ShortHandle_Ambiguous(t *testing.T) {
+	o, _ := envAddrOpts(t, "github.com/org/infra#a", "gitlab.com/org/infra#b")
+
+	err := o.Complete([]string{"infra#"})
+	if err == nil || !strings.Contains(err.Error(), "ambiguous") {
+		t.Fatalf("expected ambiguity error, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "github.com/org/infra#a") ||
+		!strings.Contains(err.Error(), "gitlab.com/org/infra#b") {
+		t.Errorf("ambiguity error should list both candidates, got: %v", err)
+	}
+}
+
+// A bare short name (no '#') must NOT match an env — it stays in binary space
+// so plain `b update <name>` can never shadow a binary.
+func TestResolveArg_BareShortName_NotEnv(t *testing.T) {
+	o, _ := envAddrOpts(t, "git@github.com:kernpilot/lok8s#main")
+
+	// 'lok8s' is not a preset/provider binary, so this should fail as a binary
+	// lookup — crucially NOT silently resolve to the env.
+	err := o.Complete([]string{"lok8s"})
+	if err == nil || !strings.Contains(err.Error(), "unknown binary or env") {
+		t.Fatalf("bare name should fall to binary space, got: %v", err)
+	}
+	if len(o.specifiedEnvRefs) != 0 {
+		t.Errorf("bare name must not resolve to an env, got %v", o.specifiedEnvRefs)
+	}
+}
+
 // The documented `b update github.com/org/infra` (no '#') must still resolve to
 // the env when it is configured as one — not get hijacked into binary space by
 // the github provider convention.
@@ -164,7 +220,9 @@ func TestUpdateValidate_ScopeFlags(t *testing.T) {
 	}{
 		{"both", UpdateOptions{EnvsOnly: true, BinariesOnly: true}, "mutually exclusive"},
 		{"binsAndGroup", UpdateOptions{BinariesOnly: true, Group: "dev"}, "cannot be combined"},
+		{"binsAndPlanJSON", UpdateOptions{BinariesOnly: true, PlanJSON: true}, "no effect with --binaries-only"},
 		{"scopeWithArgs", UpdateOptions{EnvsOnly: true, specifiedArgs: []string{"jq"}}, "no arguments"},
+		{"groupWithArgs", UpdateOptions{Group: "dev", specifiedArgs: []string{"github.com/org/infra"}}, "no arguments"},
 		{"envsOnlyOK", UpdateOptions{EnvsOnly: true}, ""},
 		{"groupOK", UpdateOptions{Group: "dev"}, ""},
 	}

--- a/pkg/cli/update_envaddr_test.go
+++ b/pkg/cli/update_envaddr_test.go
@@ -163,13 +163,42 @@ func TestRunAll_PlanJSON_BinariesOnlyConfig_EmitsEmptyArray(t *testing.T) {
 			&binary.LocalBinary{Name: "github.com/derailed/k9s", IsProviderRef: true},
 		},
 	}
-	o := &UpdateOptions{SharedOptions: shared, PlanJSON: true}
+	binariesRan := false
+	o := &UpdateOptions{
+		SharedOptions:   shared,
+		PlanJSON:        true,
+		updateBinariesF: func([]*binary.Binary) error { binariesRan = true; return nil },
+	}
 
 	if err := o.runAll(); err != nil {
 		t.Fatalf("runAll: %v", err)
 	}
 	if got := strings.TrimSpace(out.String()); got != "[]" {
 		t.Errorf("plan-json with binaries but no envs should emit '[]', got: %q", got)
+	}
+	if binariesRan {
+		t.Error("--plan-json must not run binary updates (would corrupt the JSON)")
+	}
+}
+
+// When two envs share an org/repo tail across hosts, the env hint must NOT
+// suggest the ambiguous `tail#` short handle (it wouldn't resolve) — only the
+// exact key.
+func TestEnvUpdateHint_OmitsAmbiguousShortHandle(t *testing.T) {
+	o, _ := envAddrOpts(t, "github.com/org/infra#a", "gitlab.com/org/infra#b")
+
+	hint := o.envUpdateHint("github.com/org/infra#a")
+	if !strings.Contains(hint, "github.com/org/infra#a") {
+		t.Errorf("hint should cite the exact key, got: %q", hint)
+	}
+	if strings.Contains(hint, "or short") {
+		t.Errorf("hint must not suggest the ambiguous short handle, got: %q", hint)
+	}
+
+	// A unique tail still gets the short-handle suggestion.
+	o2, _ := envAddrOpts(t, "git@github.com:kernpilot/lok8s#main")
+	if h := o2.envUpdateHint("git@github.com:kernpilot/lok8s#main"); !strings.Contains(h, "kernpilot/lok8s#") {
+		t.Errorf("unique tail should suggest the short handle, got: %q", h)
 	}
 }
 

--- a/pkg/cli/update_envaddr_test.go
+++ b/pkg/cli/update_envaddr_test.go
@@ -1,0 +1,288 @@
+package cli
+
+import (
+	"bytes"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/fentas/b/pkg/binary"
+	"github.com/fentas/b/pkg/env"
+	"github.com/fentas/b/pkg/lock"
+	"github.com/fentas/b/pkg/state"
+	"github.com/fentas/goodies/streams"
+)
+
+// envAddrOpts builds an UpdateOptions whose config carries the given env keys
+// and an empty preset set, ready for Complete() resolver tests.
+func envAddrOpts(t *testing.T, envKeys ...string) (*UpdateOptions, *bytes.Buffer) {
+	t.Helper()
+	t.Setenv("PATH_BIN", t.TempDir())
+	errBuf := &bytes.Buffer{}
+	io := &streams.IO{Out: &bytes.Buffer{}, ErrOut: errBuf}
+	shared := NewSharedOptions(io, nil)
+	envs := make(state.EnvList, 0, len(envKeys))
+	for _, k := range envKeys {
+		envs = append(envs, &state.EnvEntry{Key: k})
+	}
+	shared.Config = &state.State{Envs: envs}
+	return &UpdateOptions{SharedOptions: shared}, errBuf
+}
+
+// --- issue #166: env addressing ---
+
+// The exact SSH key `b env status` prints must round-trip back to `b update`.
+// Its '@' would be split by the binary parser, so it has to be recognized as
+// an env (via the '#' marker) before that split happens.
+func TestResolveArg_SSHEnvKey_RoundTrips(t *testing.T) {
+	o, _ := envAddrOpts(t, "git@github.com:acme/framework#main")
+
+	if err := o.Complete([]string{"git@github.com:acme/framework#main"}); err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+	if len(o.specifiedBinaries) != 0 {
+		t.Errorf("must not resolve to a binary, got %d", len(o.specifiedBinaries))
+	}
+	if len(o.specifiedEnvRefs) != 1 || o.specifiedEnvRefs[0] != "git@github.com:acme/framework#main" {
+		t.Errorf("env refs = %v, want [git@github.com:acme/framework#main]", o.specifiedEnvRefs)
+	}
+}
+
+// A label-less SSH env (no '#') still round-trips bare, via the env-exact
+// membership match that runs before binary resolution.
+func TestResolveArg_LabelLessSSHEnv_Bare(t *testing.T) {
+	o, _ := envAddrOpts(t, "git@github.com:acme/framework")
+
+	if err := o.Complete([]string{"git@github.com:acme/framework"}); err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+	if len(o.specifiedEnvRefs) != 1 || o.specifiedEnvRefs[0] != "git@github.com:acme/framework" {
+		t.Errorf("env refs = %v, want the SSH key", o.specifiedEnvRefs)
+	}
+}
+
+// A trailing '#' forces env resolution for a key that is otherwise also a
+// valid binary provider ref (the dual-namespace escape hatch).
+func TestResolveArg_TrailingHashForcesEnv(t *testing.T) {
+	o, _ := envAddrOpts(t, "github.com/org/infra")
+
+	if err := o.Complete([]string{"github.com/org/infra#"}); err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+	if len(o.specifiedBinaries) != 0 {
+		t.Errorf("trailing '#' must force env, got %d binaries", len(o.specifiedBinaries))
+	}
+	if len(o.specifiedEnvRefs) != 1 || o.specifiedEnvRefs[0] != "github.com/org/infra" {
+		t.Errorf("env refs = %v, want [github.com/org/infra]", o.specifiedEnvRefs)
+	}
+}
+
+// An env-marked arg ('#') that matches no configured env is an error — the
+// user was explicit, so we don't silently fall through to binary space.
+func TestResolveArg_EnvMarkerNoMatch_Errors(t *testing.T) {
+	o, _ := envAddrOpts(t, "github.com/org/infra")
+
+	err := o.Complete([]string{"github.com/org/nope#main"})
+	if err == nil || !strings.Contains(err.Error(), "unknown env") {
+		t.Errorf("expected unknown env error, got: %v", err)
+	}
+}
+
+// The documented `b update github.com/org/infra` (no '#') must still resolve to
+// the env when it is configured as one — not get hijacked into binary space by
+// the github provider convention.
+func TestResolveArg_HttpsEnvKey_NotHijackedByBinary(t *testing.T) {
+	o, _ := envAddrOpts(t, "github.com/org/infra")
+
+	if err := o.Complete([]string{"github.com/org/infra"}); err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+	if len(o.specifiedBinaries) != 0 {
+		t.Errorf("env key must not resolve as a binary, got %d", len(o.specifiedBinaries))
+	}
+	if len(o.specifiedEnvRefs) != 1 {
+		t.Errorf("expected 1 env ref, got %d", len(o.specifiedEnvRefs))
+	}
+}
+
+// Typing the https path of an SSH-keyed env resolves to an ad-hoc binary (a
+// legitimate operation) but prints a heads-up pointing at the matching env.
+func TestResolveArg_HttpsPathForSSHEnv_HintsEnv(t *testing.T) {
+	o, errBuf := envAddrOpts(t, "git@github.com:acme/framework#main")
+
+	if err := o.Complete([]string{"github.com/acme/framework"}); err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+	if len(o.specifiedBinaries) != 1 {
+		t.Fatalf("expected ad-hoc binary resolution, got %d", len(o.specifiedBinaries))
+	}
+	note := errBuf.String()
+	if !strings.Contains(note, "git@github.com:acme/framework#main") || !strings.Contains(note, "env") {
+		t.Errorf("expected a 'did you mean env' note, got: %q", note)
+	}
+}
+
+// A '#' inside a docker:// in-container path is a path character, not an env
+// label — the ref must stay in binary space.
+func TestResolveArg_DockerPathHash_StaysBinary(t *testing.T) {
+	o, _ := envAddrOpts(t) // no envs
+
+	if err := o.Complete([]string{"docker://alpine@3.19:/opt/we#rd/tool"}); err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+	if len(o.specifiedEnvRefs) != 0 {
+		t.Errorf("docker ref must not resolve as env, got %d", len(o.specifiedEnvRefs))
+	}
+	if len(o.specifiedBinaries) != 1 {
+		t.Errorf("expected 1 binary, got %d", len(o.specifiedBinaries))
+	}
+}
+
+// repoTail folds https and SSH forms of the same repo to one comparable tail.
+func TestRepoTail(t *testing.T) {
+	cases := map[string]string{
+		"github.com/acme/framework":     "acme/framework",
+		"git@github.com:acme/framework": "acme/framework",
+		"github.com/acme/framework.git": "acme/framework",
+		"ssh://git@host/acme/framework": "acme/framework",
+		"single":                        "",
+	}
+	for in, want := range cases {
+		if got := repoTail(in); got != want {
+			t.Errorf("repoTail(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// --- scope flags / --group implies env-only ---
+
+func TestUpdateValidate_ScopeFlags(t *testing.T) {
+	cases := []struct {
+		name    string
+		o       UpdateOptions
+		wantErr string
+	}{
+		{"both", UpdateOptions{EnvsOnly: true, BinariesOnly: true}, "mutually exclusive"},
+		{"binsAndGroup", UpdateOptions{BinariesOnly: true, Group: "dev"}, "cannot be combined"},
+		{"scopeWithArgs", UpdateOptions{EnvsOnly: true, specifiedArgs: []string{"jq"}}, "no arguments"},
+		{"envsOnlyOK", UpdateOptions{EnvsOnly: true}, ""},
+		{"groupOK", UpdateOptions{Group: "dev"}, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.o.Validate()
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Errorf("Validate() = %v, want nil", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Errorf("Validate() = %v, want error containing %q", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+// scopeHarness wires the binary + env update hooks and returns flags to inspect
+// which namespaces a runAll() invocation touched.
+type scopeHarness struct {
+	o           *UpdateOptions
+	binariesRan *bool
+	envsSynced  *[]string
+}
+
+func newScopeHarness(t *testing.T, o *UpdateOptions) scopeHarness {
+	t.Helper()
+	saveHooks(t)
+	tmpDir := t.TempDir()
+	if err := lock.WriteLock(tmpDir, &lock.Lock{}, "v1.0"); err != nil {
+		t.Fatal(err)
+	}
+
+	binariesRan := false
+	synced := []string{}
+	syncEnvFunc = func(cfg env.EnvConfig, projectRoot, cacheRoot string, lockEntry *lock.EnvEntry) (*env.SyncResult, error) {
+		synced = append(synced, cfg.Ref)
+		return &env.SyncResult{
+			Ref:     cfg.Ref,
+			Commit:  "abc",
+			Files:   []lock.LockFile{{Path: "a.yaml", Dest: "a.yaml", Status: "replaced"}},
+			Message: "1 file(s) synced",
+		}, nil
+	}
+
+	o.updateBinariesF = func(bins []*binary.Binary) error { binariesRan = true; return nil }
+	o.Yes = true
+	o.loadedConfigPath = filepath.Join(tmpDir, "b.yaml")
+	o.bVersion = "v1.0"
+	return scopeHarness{o: o, binariesRan: &binariesRan, envsSynced: &synced}
+}
+
+func scopeConfig() *state.State {
+	return &state.State{
+		Binaries: state.BinaryList{
+			&binary.LocalBinary{Name: "github.com/derailed/k9s", IsProviderRef: true},
+		},
+		Envs: state.EnvList{
+			{Key: "github.com/org/dev-config", Group: "dev"},
+			{Key: "github.com/org/shared"},
+		},
+	}
+}
+
+func TestRunAll_EnvsOnly_SkipsBinaries(t *testing.T) {
+	t.Setenv("PATH_BIN", t.TempDir())
+	io := &streams.IO{Out: &bytes.Buffer{}, ErrOut: &bytes.Buffer{}}
+	shared := NewSharedOptions(io, nil)
+	shared.Config = scopeConfig()
+	h := newScopeHarness(t, &UpdateOptions{SharedOptions: shared, EnvsOnly: true})
+
+	if err := h.o.runAll(); err != nil {
+		t.Fatalf("runAll: %v", err)
+	}
+	if *h.binariesRan {
+		t.Error("--envs-only must not run binaries")
+	}
+	if len(*h.envsSynced) != 2 {
+		t.Errorf("expected both envs synced, got %v", *h.envsSynced)
+	}
+}
+
+func TestRunAll_BinariesOnly_SkipsEnvs(t *testing.T) {
+	t.Setenv("PATH_BIN", t.TempDir())
+	io := &streams.IO{Out: &bytes.Buffer{}, ErrOut: &bytes.Buffer{}}
+	shared := NewSharedOptions(io, nil)
+	shared.Config = scopeConfig()
+	h := newScopeHarness(t, &UpdateOptions{SharedOptions: shared, BinariesOnly: true})
+
+	if err := h.o.runAll(); err != nil {
+		t.Fatalf("runAll: %v", err)
+	}
+	if !*h.binariesRan {
+		t.Error("--binaries-only should run binaries")
+	}
+	if len(*h.envsSynced) != 0 {
+		t.Errorf("--binaries-only must not sync envs, got %v", *h.envsSynced)
+	}
+}
+
+// --group is env-only, so it must skip binaries (issue #166 claim 4) and only
+// sync envs in that group.
+func TestRunAll_GroupImpliesEnvsOnly(t *testing.T) {
+	t.Setenv("PATH_BIN", t.TempDir())
+	io := &streams.IO{Out: &bytes.Buffer{}, ErrOut: &bytes.Buffer{}}
+	shared := NewSharedOptions(io, nil)
+	shared.Config = scopeConfig()
+	h := newScopeHarness(t, &UpdateOptions{SharedOptions: shared, Group: "dev"})
+
+	if err := h.o.runAll(); err != nil {
+		t.Fatalf("runAll: %v", err)
+	}
+	if *h.binariesRan {
+		t.Error("--group must not run binaries (group is env-only)")
+	}
+	if len(*h.envsSynced) != 1 || (*h.envsSynced)[0] != "github.com/org/dev-config" {
+		t.Errorf("expected only the dev env synced, got %v", *h.envsSynced)
+	}
+}

--- a/pkg/cli/update_envaddr_test.go
+++ b/pkg/cli/update_envaddr_test.go
@@ -128,6 +128,51 @@ func TestResolveArg_ShortHandle_Ambiguous(t *testing.T) {
 	}
 }
 
+// A short handle whose org segment is wrong must NOT match — suffix matching
+// compares whole segments, so `wrongorg/lok8s#` cannot reach kernpilot/lok8s.
+func TestResolveArg_ShortHandle_WrongOrg(t *testing.T) {
+	o, _ := envAddrOpts(t, "git@github.com:kernpilot/lok8s#main")
+
+	err := o.Complete([]string{"wrongorg/lok8s#"})
+	if err == nil || !strings.Contains(err.Error(), "unknown env") {
+		t.Fatalf("wrong org should not match, want unknown env, got: %v", err)
+	}
+}
+
+// Short-handle matching is case-insensitive.
+func TestResolveArg_ShortHandle_CaseInsensitive(t *testing.T) {
+	o, _ := envAddrOpts(t, "git@github.com:kernpilot/lok8s#main")
+
+	if err := o.Complete([]string{"LOK8S#"}); err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+	if len(o.specifiedEnvRefs) != 1 || o.specifiedEnvRefs[0] != "git@github.com:kernpilot/lok8s#main" {
+		t.Errorf("case-insensitive handle → %v, want the SSH key", o.specifiedEnvRefs)
+	}
+}
+
+// --plan-json with binaries configured but no envs must still emit a valid
+// (empty) JSON array — binaries never appear in the plan (Copilot round-2).
+func TestRunAll_PlanJSON_BinariesOnlyConfig_EmitsEmptyArray(t *testing.T) {
+	t.Setenv("PATH_BIN", t.TempDir())
+	out := &bytes.Buffer{}
+	io := &streams.IO{Out: out, ErrOut: &bytes.Buffer{}}
+	shared := NewSharedOptions(io, nil)
+	shared.Config = &state.State{
+		Binaries: state.BinaryList{
+			&binary.LocalBinary{Name: "github.com/derailed/k9s", IsProviderRef: true},
+		},
+	}
+	o := &UpdateOptions{SharedOptions: shared, PlanJSON: true}
+
+	if err := o.runAll(); err != nil {
+		t.Fatalf("runAll: %v", err)
+	}
+	if got := strings.TrimSpace(out.String()); got != "[]" {
+		t.Errorf("plan-json with binaries but no envs should emit '[]', got: %q", got)
+	}
+}
+
 // A bare short name (no '#') must NOT match an env — it stays in binary space
 // so plain `b update <name>` can never shadow a binary.
 func TestResolveArg_BareShortName_NotEnv(t *testing.T) {
@@ -173,8 +218,13 @@ func TestResolveArg_HttpsPathForSSHEnv_HintsEnv(t *testing.T) {
 		t.Fatalf("expected ad-hoc binary resolution, got %d", len(o.specifiedBinaries))
 	}
 	note := errBuf.String()
-	if !strings.Contains(note, "git@github.com:acme/framework#main") || !strings.Contains(note, "env") {
-		t.Errorf("expected a 'did you mean env' note, got: %q", note)
+	if !strings.Contains(note, "git@github.com:acme/framework#main") {
+		t.Errorf("note should cite the exact env key, got: %q", note)
+	}
+	// The hint must offer a WORKING form — a short handle — not "append '#'" to
+	// the https arg, which would not match the SSH key (Copilot round-2).
+	if !strings.Contains(note, "acme/framework#") {
+		t.Errorf("note should suggest the working short handle, got: %q", note)
 	}
 }
 

--- a/pkg/gitcache/gitcache.go
+++ b/pkg/gitcache/gitcache.go
@@ -372,6 +372,40 @@ func RefVersion(ref string) string {
 	return ""
 }
 
+// RepoPath returns the transport-independent path segments identifying the repo
+// in ref: scheme, an SSH "user@host:"/"user@host/" prefix, version, label, and
+// any .git suffix are removed. e.g. "git@github.com:org/repo.git#main" →
+// ["org","repo"]; "https://github.com/org/repo" → ["github.com","org","repo"];
+// "ssh://git@host/org/repo" → ["org","repo"].
+//
+// Unlike GitURL, which preserves transport (the clone URL differs for ssh vs
+// https), RepoPath describes repo IDENTITY, so different transport forms of the
+// same repo yield comparable trailing segments. Returns nil for local paths.
+func RepoPath(ref string) []string {
+	if isLocalPath(ref) {
+		return nil
+	}
+	base := strings.TrimSuffix(RefBase(ref), ".git")
+	if i := strings.LastIndex(base, "://"); i >= 0 {
+		base = base[i+3:]
+	}
+	// Drop an SSH scp-style "user@host:" or bare "host:" prefix (a colon with
+	// no slash before it); "host/org/repo" style paths are left intact.
+	if i := strings.Index(base, ":"); i >= 0 && !strings.Contains(base[:i], "/") {
+		base = base[i+1:]
+	}
+	base = strings.Trim(base, "/")
+	if base == "" {
+		return nil
+	}
+	parts := strings.Split(base, "/")
+	// Drop a leading "user@host" segment from the ssh:// explicit form.
+	if len(parts) > 1 && strings.Contains(parts[0], "@") {
+		parts = parts[1:]
+	}
+	return parts
+}
+
 // isLocalPath returns true if the ref looks like a local filesystem path.
 func isLocalPath(ref string) bool {
 	return strings.HasPrefix(ref, "/") || strings.HasPrefix(ref, "./") || strings.HasPrefix(ref, "../")

--- a/pkg/gitcache/gitcache.go
+++ b/pkg/gitcache/gitcache.go
@@ -385,21 +385,29 @@ func RepoPath(ref string) []string {
 	if isLocalPath(ref) {
 		return nil
 	}
-	base := strings.TrimSuffix(RefBase(ref), ".git")
-	if i := strings.LastIndex(base, "://"); i >= 0 {
+	base := RefBase(ref)
+	hadScheme := false
+	if i := strings.Index(base, "://"); i >= 0 {
 		base = base[i+3:]
-	}
-	// Drop an SSH scp-style "user@host:" or bare "host:" prefix (a colon with
-	// no slash before it); "host/org/repo" style paths are left intact.
-	if i := strings.Index(base, ":"); i >= 0 && !strings.Contains(base[:i], "/") {
-		base = base[i+1:]
+		hadScheme = true
 	}
 	base = strings.Trim(base, "/")
+	// Drop an scp-style "user@host:" or bare "host:" prefix (a colon with no
+	// slash before it) — but ONLY when there was no explicit scheme. With a
+	// scheme, a colon before the first slash is a host:port, not an scp path
+	// separator (e.g. ssh://host:2222/org/repo, https://host:443/org/repo).
+	if !hadScheme {
+		if i := strings.Index(base, ":"); i >= 0 && !strings.Contains(base[:i], "/") {
+			base = base[i+1:]
+		}
+	}
+	// Trim a .git suffix after slashes are gone so "repo.git/" normalizes too.
+	base = strings.Trim(strings.TrimSuffix(base, ".git"), "/")
 	if base == "" {
 		return nil
 	}
 	parts := strings.Split(base, "/")
-	// Drop a leading "user@host" segment from the ssh:// explicit form.
+	// Drop a leading "user@host[:port]" segment from the ssh:// explicit form.
 	if len(parts) > 1 && strings.Contains(parts[0], "@") {
 		parts = parts[1:]
 	}

--- a/pkg/gitcache/gitcache_extra_test.go
+++ b/pkg/gitcache/gitcache_extra_test.go
@@ -72,6 +72,35 @@ func TestRefBase_EdgeCases(t *testing.T) {
 	}
 }
 
+func TestRepoPath(t *testing.T) {
+	tests := []struct {
+		ref  string
+		want []string
+	}{
+		{"github.com/org/repo", []string{"github.com", "org", "repo"}},
+		{"git@github.com:org/repo", []string{"org", "repo"}},
+		{"git@github.com:org/repo.git#main", []string{"org", "repo"}},
+		{"github.com/org/repo@v2.0", []string{"github.com", "org", "repo"}},
+		{"ssh://git@host/org/repo", []string{"org", "repo"}},
+		{"single", []string{"single"}},
+		{"/abs/local/path", nil},
+		{"./rel", nil},
+	}
+	for _, tt := range tests {
+		got := RepoPath(tt.ref)
+		if len(got) != len(tt.want) {
+			t.Errorf("RepoPath(%q) = %v, want %v", tt.ref, got, tt.want)
+			continue
+		}
+		for i := range got {
+			if got[i] != tt.want[i] {
+				t.Errorf("RepoPath(%q) = %v, want %v", tt.ref, got, tt.want)
+				break
+			}
+		}
+	}
+}
+
 func TestRefLabel_EdgeCases(t *testing.T) {
 	tests := []struct {
 		ref  string

--- a/pkg/gitcache/gitcache_extra_test.go
+++ b/pkg/gitcache/gitcache_extra_test.go
@@ -82,6 +82,11 @@ func TestRepoPath(t *testing.T) {
 		{"git@github.com:org/repo.git#main", []string{"org", "repo"}},
 		{"github.com/org/repo@v2.0", []string{"github.com", "org", "repo"}},
 		{"ssh://git@host/org/repo", []string{"org", "repo"}},
+		// host:port must not be mistaken for an scp "host:path" separator.
+		{"ssh://git@host:2222/org/repo", []string{"org", "repo"}},
+		{"https://github.com:443/org/repo", []string{"github.com:443", "org", "repo"}},
+		// .git must be stripped even with a trailing slash.
+		{"github.com/org/repo.git/", []string{"github.com", "org", "repo"}},
 		{"single", []string{"single"}},
 		{"/abs/local/path", nil},
 		{"./rel", nil},


### PR DESCRIPTION
Fixes #166.

## Problem

`b update <arg>` resolved every arg through the **binary** parser first (`provider.ParseRef`), which splits on `@` and is not SSH-aware. So:

- The exact key `b env status` prints for an SSH-keyed env (`git@github.com:org/repo#main`) could never be passed back — it parsed to `git` and failed as *"unknown binary or env: git"*.
- A path like `github.com/acme/framework` silently fell into binary space → *"release not found"*.
- `--group` filtered only envs while still updating **every binary**, so there was no way to refresh vendored env content without toolchain churn.

Root cause: one flat positional addresses two namespaces (binaries + envs) with overlapping grammars, and we committed to the binary grammar before the env namespace (which has the SSH-aware parser) was ever consulted.

## Fix — resolve by config membership + an env marker

`resolveUpdateArg` now decides by what's actually in `b.yaml`, not by guessing from shape:

- `docker://` / `oci://` / `go://` → always binary (`#` there is a path/module char, never an env label).
- A **local path**, or a **`#`** outside those protocols → env marker: resolve as env (SSH/local-aware), error if no such env (the user was explicit).
- Otherwise → match envs by **exact/canonical key before** binary space, so the printed key round-trips and an env ref isn't hijacked by the `github.com/org/repo` provider convention. A **trailing `#`** forces env for keys that are also valid binary refs (dual-namespace escape hatch).
- Typing the https path of an SSH-keyed env still resolves to an ad-hoc binary but prints a *"did you mean env …"* hint.

## Scope flags

- `--group` now **implies env-only** (groups are an env-only concept — binaries have no group). This is the direct fix for the `--group` part of #166.
- Added `--envs-only` / `--binaries-only`, validated mutually-exclusive and rejected alongside explicit args.

## Notes

- The issue's "minor" item (a generated `b.yaml` header saying *"Run `b env sync`"*) is **already gone** from current source — nothing to change.
- Deliberately **not** rewriting env keys in `b.yaml` on save; the membership resolver makes it unnecessary, and silently rewriting user keys is the class of bug we fixed in #159.

## Tests

`pkg/cli/update_envaddr_test.go` (19 cases): SSH-key round-trip, label-less SSH bare, trailing-`#` force, env-marker-no-match error, https-key-not-hijacked regression guard, claim-3 hint, docker-`#`-stays-binary, `repoTail` folding, scope-flag validation, and three `runAll` scoping tests. `go build`, `go vet ./...`, `gofmt`, full `go test ./...` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)