### PR TITLE
docs(env): stop CLI help pointing at non-existent `b env update`/`b env sync`

### DIFF
--- a/pkg/cli/env.go
+++ b/pkg/cli/env.go
@@ -178,7 +178,7 @@ func hashAndScanConflicts(path string) (string, bool, error) {
 func NewEnvCmd(shared *SharedOptions) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "env",
-		Short: "Inspect and configure env file sync",
+		Short: "Inspect and manage env file sync settings",
 		Long: `Commands for inspecting and configuring env file sync.
 
 The sync itself runs from the top level — there is no ` + "`b env sync`" + ` or

--- a/pkg/cli/env.go
+++ b/pkg/cli/env.go
@@ -178,8 +178,13 @@ func hashAndScanConflicts(path string) (string, bool, error) {
 func NewEnvCmd(shared *SharedOptions) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "env",
-		Short: "Manage environment file sync",
-		Long:  "Commands for inspecting and managing env file syncing.",
+		Short: "Inspect and configure env file sync",
+		Long: `Commands for inspecting and configuring env file sync.
+
+The sync itself runs from the top level — there is no ` + "`b env sync`" + ` or
+` + "`b env update`" + ` subcommand. Use ` + "`b update`" + ` (or ` + "`b install`" + `) to pull
+and update env files; ` + "`b update --envs-only`" + ` syncs envs without touching
+binaries.`,
 	}
 
 	cmd.AddCommand(NewEnvStatusCmd(shared))

--- a/pkg/cli/env.go
+++ b/pkg/cli/env.go
@@ -181,10 +181,8 @@ func NewEnvCmd(shared *SharedOptions) *cobra.Command {
 		Short: "Inspect and manage env file sync settings",
 		Long: `Commands for inspecting and configuring env file sync.
 
-The sync itself runs from the top level — there is no ` + "`b env sync`" + ` or
-` + "`b env update`" + ` subcommand. Use ` + "`b update`" + ` (or ` + "`b install`" + `) to pull
-and update env files; ` + "`b update --envs-only`" + ` syncs envs without touching
-binaries.`,
+The sync itself runs from the top level — there is no ` + "`b env sync`" + ` or ` + "`b env update`" + ` subcommand.
+Use ` + "`b update`" + ` (or ` + "`b install`" + `) to pull and update env files, or ` + "`b update --envs-only`" + ` to sync envs without touching binaries.`,
 	}
 
 	cmd.AddCommand(NewEnvStatusCmd(shared))

--- a/pkg/cli/env_resolve.go
+++ b/pkg/cli/env_resolve.go
@@ -18,9 +18,9 @@ import (
 // EnvResolveOptions holds options for `b env resolve`.
 //
 // The command lists files that contain unresolved git-style conflict
-// markers (left there by `b env update` after a 3-way merge couldn't
-// auto-merge a hunk) and optionally rewrites them in bulk by picking
-// one side of every conflict region.
+// markers (left there by `b update --strategy=merge` after a 3-way merge
+// couldn't auto-merge a hunk) and optionally rewrites them in bulk by
+// picking one side of every conflict region.
 //
 // Conflict marker shape (the `git merge-file --diff3` output b uses):
 //
@@ -48,9 +48,13 @@ func NewEnvResolveCmd(shared *SharedOptions) *cobra.Command {
 	o := &EnvResolveOptions{SharedOptions: shared}
 	cmd := &cobra.Command{
 		Use:   "resolve [env...]",
-		Short: "List or auto-resolve merge conflicts left by `b env update`",
+		Short: "List or auto-resolve merge conflicts left by `b update --strategy=merge`",
 		Long: `Inspect synced env files for unresolved git-style merge conflict markers
 and optionally pick a side in bulk.
+
+Env files are synced by ` + "`b update`" + ` / ` + "`b install`" + ` (there is no
+` + "`b env sync`" + ` or ` + "`b env update`" + ` subcommand); conflict markers are
+left when a ` + "`--strategy=merge`" + ` sync can't auto-merge a hunk.
 
 Without --ours or --theirs the command lists every conflicted file. With
 either flag, the listed files are rewritten in place by keeping that

--- a/pkg/cli/env_resolve.go
+++ b/pkg/cli/env_resolve.go
@@ -54,7 +54,8 @@ and optionally pick a side in bulk.
 
 Env files are synced by ` + "`b update`" + ` / ` + "`b install`" + ` (there is no
 ` + "`b env sync`" + ` or ` + "`b env update`" + ` subcommand); conflict markers are
-left when a ` + "`--strategy=merge`" + ` sync can't auto-merge a hunk.
+left when ` + "`b update --strategy=merge`" + ` can't auto-merge a hunk
+(` + "`--strategy`" + ` is a ` + "`b update`" + ` flag).
 
 Without --ours or --theirs the command lists every conflicted file. With
 either flag, the listed files are rewritten in place by keeping that

--- a/pkg/cli/env_resolve.go
+++ b/pkg/cli/env_resolve.go
@@ -52,10 +52,8 @@ func NewEnvResolveCmd(shared *SharedOptions) *cobra.Command {
 		Long: `Inspect synced env files for unresolved git-style merge conflict markers
 and optionally pick a side in bulk.
 
-Env files are synced by ` + "`b update`" + ` / ` + "`b install`" + ` (there is no
-` + "`b env sync`" + ` or ` + "`b env update`" + ` subcommand); conflict markers are
-left when ` + "`b update --strategy=merge`" + ` can't auto-merge a hunk
-(` + "`--strategy`" + ` is a ` + "`b update`" + ` flag).
+Env files are synced by ` + "`b update`" + ` / ` + "`b install`" + ` (there is no ` + "`b env sync`" + ` or ` + "`b env update`" + ` subcommand).
+Conflict markers are left when ` + "`b update --strategy=merge`" + ` can't auto-merge a hunk (` + "`--strategy`" + ` is a ` + "`b update`" + ` flag).
 
 Without --ours or --theirs the command lists every conflicted file. With
 either flag, the listed files are rewritten in place by keeping that


### PR DESCRIPTION
## Problem

`b env resolve`'s help — shown right in `b env --help` — described itself as resolving *"merge conflicts left by `b env update`"*, a subcommand that **does not exist**. `b env`'s real subcommands are `add / match / profiles / remove / resolve / status`; the sync verbs are top-level (`b update` / `b install`).

It's a trap, not just a typo:
- `b env` reads like where sync lives (it has half a dozen subcommands), so you don't suspect the verb is one level up.
- Running `b env sync` / `b env update` **silently prints the env help and exits 0** — no "unknown command" error.
- The CLI's own `resolve` help then points at the ghost `b env update`.

Surfaced from the `kernpilot/kubehz-cluster` scaffold, whose `b.yaml` header also says `b env sync` (that header is hand-authored by the lok8s scaffold, not emitted by `b` — it should say `b update --envs-only`).

## Fix (help/comment text only — no behavior change)

- **`b env resolve`**: reference `b update --strategy=merge` (what actually leaves the conflict markers) instead of `b env update`, in both the `Short` help and the doc comment. `Long` now states plainly that there is no `b env sync`/`b env update` subcommand.
- **`b env` parent**: `Short`/`Long` clarify that sync runs from the top level — `b update` / `b install`, with `b update --envs-only` to skip binaries — and that `b env` is for inspecting/configuring only.

## Verification

`b env --help` now shows:
```
resolve   List or auto-resolve merge conflicts left by `b update --strategy=merge`
```
and the `env` header explains where sync lives. `go build`, `go vet ./...`, `gofmt`, full `go test ./...` all clean.

> Note: pushed over HTTPS via the gh token — the local ssh-agent had dropped its key this session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)