### PR TITLE
fix(env): status/remove resolve file paths against project root, not lockDir

### DIFF
--- a/pkg/cli/env.go
+++ b/pkg/cli/env.go
@@ -233,6 +233,13 @@ func (o *EnvStatusOptions) Run() error {
 		return err
 	}
 
+	// Env file dests are stored relative to the project root (that's the base
+	// SyncEnv writes and validates against — pkg/env/env.go), NOT the config
+	// dir. Resolving them against lockDir here made `b env status` report every
+	// file "missing" whenever the config lived in a subdir like .bin/ (the
+	// default layout), because it stat'd .bin/<dest> instead of <root>/<dest>.
+	projectRoot := o.ProjectRoot()
+
 	for _, entry := range o.Config.Envs {
 		label := gitcache.RefLabel(entry.Key)
 		ref := gitcache.RefBase(entry.Key)
@@ -276,12 +283,12 @@ func (o *EnvStatusOptions) Run() error {
 		for _, f := range lockEntry.Files {
 			destPath := f.Dest
 			if !filepath.IsAbs(destPath) {
-				destPath = filepath.Join(lockDir, destPath)
+				destPath = filepath.Join(projectRoot, destPath)
 			}
 			destPath = filepath.Clean(destPath)
 
 			// Skip paths that escape the project root (including via symlinks)
-			if err := env.ValidatePathUnderRoot(lockDir, destPath); err != nil {
+			if err := env.ValidatePathUnderRoot(projectRoot, destPath); err != nil {
 				localDrift++
 				continue
 			}
@@ -413,17 +420,21 @@ func (o *EnvRemoveOptions) Run(key string) error {
 		if err != nil {
 			return err
 		}
+		// Dests are project-root-relative (the base SyncEnv writes against), not
+		// config-dir-relative — resolving against lockDir here silently missed
+		// the real files (and orphaned them) on the default .bin/ layout.
+		projectRoot := o.ProjectRoot()
 		lockEntry := lk.FindEnv(ref, label)
 		if lockEntry != nil {
 			for _, f := range lockEntry.Files {
 				destPath := f.Dest
 				if !filepath.IsAbs(destPath) {
-					destPath = filepath.Join(lockDir, destPath)
+					destPath = filepath.Join(projectRoot, destPath)
 				}
 				destPath = filepath.Clean(destPath)
 
 				// Path traversal check (including symlinks): refuse to delete outside project root
-				if err := env.ValidatePathUnderRoot(lockDir, destPath); err != nil {
+				if err := env.ValidatePathUnderRoot(projectRoot, destPath); err != nil {
 					fmt.Fprintf(o.IO.ErrOut, "  Warning: skipping %s (resolves outside project root)\n", f.Dest)
 					continue
 				}

--- a/pkg/cli/env_test.go
+++ b/pkg/cli/env_test.go
@@ -90,6 +90,8 @@ func TestEnvStatus_UpToDate(t *testing.T) {
 	}
 
 	tmpDir := t.TempDir()
+	// Env dests resolve against the project root, so pin it to tmpDir.
+	t.Setenv("PATH_BASE", tmpDir)
 	// Create a synced file
 	destPath := filepath.Join(tmpDir, "test.yaml")
 	os.WriteFile(destPath, []byte("content"), 0644)
@@ -135,6 +137,7 @@ func TestEnvStatus_UpstreamChanged(t *testing.T) {
 	}
 
 	tmpDir := t.TempDir()
+	t.Setenv("PATH_BASE", tmpDir)
 	destPath := filepath.Join(tmpDir, "test.yaml")
 	os.WriteFile(destPath, []byte("content"), 0644)
 	hash, _ := lock.SHA256File(destPath)
@@ -178,6 +181,7 @@ func TestEnvStatus_LocalDrift(t *testing.T) {
 	}
 
 	tmpDir := t.TempDir()
+	t.Setenv("PATH_BASE", tmpDir)
 	destPath := filepath.Join(tmpDir, "test.yaml")
 	os.WriteFile(destPath, []byte("modified content"), 0644)
 
@@ -220,6 +224,7 @@ func TestEnvStatus_PathTraversalInLock(t *testing.T) {
 	}
 
 	tmpDir := t.TempDir()
+	t.Setenv("PATH_BASE", tmpDir)
 
 	// Lock entry with a path that escapes project root
 	lk := &lock.Lock{
@@ -253,6 +258,60 @@ func TestEnvStatus_PathTraversalInLock(t *testing.T) {
 	// Should count the escaping path as drift, not try to read /etc/passwd
 	if !strings.Contains(out.String(), "modified locally") {
 		t.Errorf("expected drift for path traversal entry, got: %q", out.String())
+	}
+}
+
+// TestEnvStatus_DefaultBinLayout_FindsFiles is the regression for the default
+// `.bin/b.yaml` layout, where lockDir (<root>/.bin) differs from the project
+// root (<root>). Env files are written relative to the project root, so status
+// must resolve dests there — not under lockDir, which made it stat
+// <root>/.bin/<dest> and falsely report every file missing (issue: successful
+// sync still reports everything "missing").
+func TestEnvStatus_DefaultBinLayout_FindsFiles(t *testing.T) {
+	saveHooks(t)
+	resolveRefFunc = func(url, version string) (string, error) { return "abc123def456", nil }
+
+	root := t.TempDir()
+	t.Setenv("PATH_BASE", root) // projectRoot = root
+	binDir := filepath.Join(root, ".bin")
+	if err := os.MkdirAll(binDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// File lives at the project root (where SyncEnv writes it), NOT under .bin.
+	destPath := filepath.Join(root, "manifests", "deploy.yaml")
+	if err := os.MkdirAll(filepath.Dir(destPath), 0755); err != nil {
+		t.Fatal(err)
+	}
+	os.WriteFile(destPath, []byte("content"), 0644)
+	hash, _ := lock.SHA256File(destPath)
+
+	// Lock lives in .bin (lockDir); dest is project-root-relative.
+	lk := &lock.Lock{
+		Envs: []lock.EnvEntry{{
+			Ref:    "github.com/org/infra",
+			Commit: "abc123def456",
+			Files:  []lock.LockFile{{Path: "manifests/deploy.yaml", Dest: "manifests/deploy.yaml", SHA256: hash}},
+		}},
+	}
+	lock.WriteLock(binDir, lk, "v1.0")
+
+	out := &bytes.Buffer{}
+	io := &streams.IO{Out: out, ErrOut: &bytes.Buffer{}}
+	shared := NewSharedOptions(io, nil)
+	shared.Config = &state.State{Envs: state.EnvList{{Key: "github.com/org/infra"}}}
+	shared.loadedConfigPath = filepath.Join(binDir, "b.yaml") // lockDir = <root>/.bin
+
+	o := &EnvStatusOptions{SharedOptions: shared}
+	if err := o.Run(); err != nil {
+		t.Fatalf("Run error: %v", err)
+	}
+	got := out.String()
+	if strings.Contains(got, "missing") {
+		t.Errorf("status falsely reported missing on .bin layout: %q", got)
+	}
+	if !strings.Contains(got, "up to date") {
+		t.Errorf("expected 'up to date', got: %q", got)
 	}
 }
 
@@ -336,6 +395,7 @@ func TestEnvRemove_RemovesFromLock(t *testing.T) {
 
 func TestEnvRemove_DeletesFiles(t *testing.T) {
 	tmpDir := t.TempDir()
+	t.Setenv("PATH_BASE", tmpDir)
 
 	// Create synced file
 	destPath := filepath.Join(tmpDir, "deploy.yaml")
@@ -368,6 +428,50 @@ func TestEnvRemove_DeletesFiles(t *testing.T) {
 
 	if _, err := os.Stat(destPath); !os.IsNotExist(err) {
 		t.Error("synced file should be deleted")
+	}
+}
+
+// TestEnvRemove_DeletesFiles_DefaultBinLayout is the sibling regression: with
+// config in <root>/.bin, --delete-files must remove the file at the project
+// root (<root>/<dest>), not look under lockDir (<root>/.bin/<dest>) and
+// silently orphan it.
+func TestEnvRemove_DeletesFiles_DefaultBinLayout(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("PATH_BASE", root)
+	binDir := filepath.Join(root, ".bin")
+	if err := os.MkdirAll(binDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	destPath := filepath.Join(root, "manifests", "deploy.yaml")
+	if err := os.MkdirAll(filepath.Dir(destPath), 0755); err != nil {
+		t.Fatal(err)
+	}
+	os.WriteFile(destPath, []byte("content"), 0644)
+
+	lk := &lock.Lock{
+		Envs: []lock.EnvEntry{{
+			Ref:    "github.com/org/infra",
+			Commit: "abc",
+			Files:  []lock.LockFile{{Path: "manifests/deploy.yaml", Dest: "manifests/deploy.yaml"}},
+		}},
+	}
+	lock.WriteLock(binDir, lk, "v1.0")
+
+	out := &bytes.Buffer{}
+	io := &streams.IO{Out: out, ErrOut: &bytes.Buffer{}}
+	shared := NewSharedOptions(io, nil)
+	shared.Config = &state.State{}
+	shared.loadedConfigPath = filepath.Join(binDir, "b.yaml")
+	shared.bVersion = "v1.0"
+
+	o := &EnvRemoveOptions{SharedOptions: shared, DeleteFiles: true}
+	if err := o.Run("github.com/org/infra"); err != nil {
+		t.Fatalf("Run error: %v", err)
+	}
+
+	if _, err := os.Stat(destPath); !os.IsNotExist(err) {
+		t.Error("file at project root should be deleted on .bin layout (not orphaned)")
 	}
 }
 


### PR DESCRIPTION
## Problem

After a **successful** `b update --envs-only`, `b env status` reported every env file as missing:

```
lok8s#main @ 88d3620        ← lock advanced (sync recorded)
  ✗ 223 file(s) missing     ← but the whole tree is present & byte-identical
```

Root cause: `b env status` (and `b env remove --delete-files`) resolve each lock entry's `Dest` against **`lockDir`** (the config dir), but the writer `SyncEnv` — and `b env resolve` — resolve dests against the **project root** (`pkg/env/env.go:72`: *"projectRoot is the base directory for resolving dest paths"*).

On the **default `.bin/b.yaml` layout** these differ:
- `lockDir` = `<root>/.bin`
- `projectRoot` = `<root>` (git root)

So `update` writes `<root>/.lok8s/...` (correct) while `status` stats `<root>/.bin/.lok8s/...` → not there → all files "missing", even though the lock advanced and the files are byte-identical to upstream. The per-file ledger *was* repopulated (that's why the count is exact, e.g. 222→223) — status just looked in the wrong directory.

**Sibling bug:** `b env remove --delete-files` had the same wrong base, so it looked under `.bin`, found nothing, and **silently orphaned** the real files (`os.Remove` swallows `IsNotExist`).

This hits anyone using the default `.bin/` layout with envs; the `b` repo's own `.bin/b.yaml` has no envs, so dogfooding never caught it.

## Fix

`b env status` and `b env remove --delete-files` now resolve `Dest` + `ValidatePathUnderRoot` against `o.ProjectRoot()`, matching `SyncEnv` and `b env resolve`.

## Tests

- New `TestEnvStatus_DefaultBinLayout_FindsFiles` and `TestEnvRemove_DeletesFiles_DefaultBinLayout` exercise `lockDir != projectRoot` (config in `.bin/`, files at root) — both **fail without this fix** (reproduce "1 file(s) missing" / orphaned file) and pass with it.
- The existing status/remove file tests pinned `PATH_BASE` so `projectRoot==tmpDir`; they previously passed only because they wrote fixtures at `lockDir/<dest>`, which masked the bug.

`go build`, `go vet ./...`, `gofmt`, full `go test ./...` all clean.

> Pushed over HTTPS via the gh token — the local ssh-agent has no key this session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)