### PR TITLE
fix(verify): resolve env file paths against project root, not lockDir

### DIFF
--- a/pkg/cli/more_coverage_test.go
+++ b/pkg/cli/more_coverage_test.go
@@ -174,6 +174,9 @@ func TestNewListCmd(t *testing.T) {
 
 func TestVerifyRun_WithEntries(t *testing.T) {
 	dir := t.TempDir()
+	// Env dests resolve against the project root; pin it to dir so the matching
+	// a.yaml below is genuinely checked rather than resolving to the repo root.
+	t.Setenv("PATH_BASE", dir)
 	binDir := filepath.Join(dir, ".bin")
 	if err := os.MkdirAll(binDir, 0755); err != nil {
 		t.Fatalf("MkdirAll: %v", err)
@@ -235,6 +238,53 @@ func TestVerifyRun_WithEntries(t *testing.T) {
 	// Lock has intentional mismatches/missing files — Run should report failures.
 	if err := o.Run(); err == nil {
 		t.Error("expected verify to return an error for mismatched/missing entries")
+	}
+}
+
+// TestVerifyRun_DefaultBinLayout_FindsEnvFiles is the regression for the default
+// `.bin/b.yaml` layout: lockDir is <root>/.bin but env files live at the project
+// root (<root>/<dest>). verify must resolve dests against the project root — not
+// lockDir, which made it stat <root>/.bin/<dest> and report present, matching
+// files as "missing" (b verify unusable on envs synced into the project root).
+func TestVerifyRun_DefaultBinLayout_FindsEnvFiles(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("PATH_BASE", root) // projectRoot = root
+	binDir := filepath.Join(root, ".bin")
+	if err := os.MkdirAll(binDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Env file at the project root (where SyncEnv writes it), not under .bin.
+	envPath := filepath.Join(root, "configs", "a.yaml")
+	if err := os.MkdirAll(filepath.Dir(envPath), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(envPath, []byte("data"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	envHash, err := lock.SHA256File(envPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Lock lives in .bin (lockDir); dest is project-root-relative.
+	lk := &lock.Lock{
+		Version: 1,
+		Envs: []lock.EnvEntry{
+			{Ref: "github.com/org/infra", Files: []lock.LockFile{
+				{Path: "a.yaml", Dest: "configs/a.yaml", SHA256: envHash},
+			}},
+		},
+	}
+	if err := lock.WriteLock(binDir, lk, "test"); err != nil {
+		t.Fatal(err)
+	}
+
+	shared := NewSharedOptions(mkIO(), nil)
+	shared.ConfigPath = filepath.Join(binDir, "b.yaml") // lockDir = <root>/.bin
+	o := &VerifyOptions{SharedOptions: shared}
+	if err := o.Run(); err != nil {
+		t.Errorf("verify should pass for a present, matching env file on .bin layout, got: %v", err)
 	}
 }
 

--- a/pkg/cli/verify.go
+++ b/pkg/cli/verify.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/fentas/b/pkg/env"
 	"github.com/fentas/b/pkg/lock"
 	"github.com/fentas/b/pkg/path"
 	"github.com/fentas/goodies/templates"
@@ -82,18 +83,32 @@ func (o *VerifyOptions) Run() error {
 		}
 	}
 
+	// Env file dests are stored relative to the project root (the base SyncEnv
+	// writes against — pkg/env/env.go), NOT the config dir. Resolving against
+	// LockDir made `b verify` report every env file "missing" on the default
+	// .bin/ layout, where lockDir (.bin) differs from the project root.
+	projectRoot := o.ProjectRoot()
+
 	// Verify env files
-	for _, env := range lk.Envs {
+	for _, envEntry := range lk.Envs {
 		label := ""
-		if env.Label != "" {
-			label = "#" + env.Label
+		if envEntry.Label != "" {
+			label = "#" + envEntry.Label
 		}
-		fmt.Fprintf(o.IO.Out, "  %s%s\n", env.Ref, label)
-		for _, f := range env.Files {
-			// Resolve dest relative to project root
+		fmt.Fprintf(o.IO.Out, "  %s%s\n", envEntry.Ref, label)
+		for _, f := range envEntry.Files {
 			destPath := f.Dest
 			if !filepath.IsAbs(destPath) {
-				destPath = filepath.Join(dir, destPath)
+				destPath = filepath.Join(projectRoot, destPath)
+			}
+			destPath = filepath.Clean(destPath)
+			// Refuse to read paths that escape the project root — a malicious or
+			// hand-edited lock must not make verify stat arbitrary files. Matches
+			// the guard in env status/remove/resolve.
+			if err := env.ValidatePathUnderRoot(projectRoot, destPath); err != nil {
+				fmt.Fprintf(o.IO.Out, "    %-38s ✗ escapes project root\n", f.Dest)
+				failures++
+				continue
 			}
 			if _, err := os.Stat(destPath); os.IsNotExist(err) {
 				fmt.Fprintf(o.IO.Out, "    %-38s ✗ missing\n", f.Dest)


### PR DESCRIPTION
## Problem

Follow-up to #170. That PR fixed the env-dest path-resolution bug in `b env status` and `b env remove --delete-files`, but **`b verify` has the identical bug** and wasn't touched:

```
$ b verify
  skills/lok8s-implement/SKILL.md  ✗ missing      ← actually exists at ./skills/…
  Error: 342 artifact(s) differ from lock
```

`verify.go` resolved each lock entry's env `Dest` against `dir = o.LockDir()` (the config dir), while `SyncEnv` — the writer — writes them relative to the **project root**. On the default `.bin/b.yaml` layout (`lockDir=<root>/.bin`, `projectRoot=<root>`) verify stat'd `<root>/.bin/<dest>`, so every present env file was reported "missing" and `b verify` failed on any env synced into the project root. (The code comment even said "Resolve dest relative to project root" while using `lockDir`.)

## Fix

`b verify` now resolves env dests against `o.ProjectRoot()`, matching `SyncEnv` and `b env status`/`remove`/`resolve`. It also gains the same `ValidatePathUnderRoot` guard the sibling commands have (a hand-edited lock can't make verify stat files outside the root). **Binary** verification is unchanged (still uses the binary path).

**This completes the sweep** — every env-dest reader (status, remove, resolve, `printConflictHint`, verify) now resolves against the project root; no reader uses `lockDir`.

## Tests

- New `TestVerifyRun_DefaultBinLayout_FindsEnvFiles` covers `lockDir != projectRoot` and **fails without this fix** (reproduces "1 artifact(s) differ from lock" for a present, matching file).
- `TestVerifyRun_WithEntries` now pins `PATH_BASE` — it previously passed only via *unrelated* intentional failures, so its "matching" env file was never actually exercised.

`go build`, `go vet ./...`, `gofmt`, full `go test ./...` all clean.

> Targets 4.18.1: since the release PR (#171) isn't merged yet, release-please will fold this into the same 4.18.1 so status + remove + verify all ship together.
> Pushed over HTTPS via the gh token (ssh-agent has no key this session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)