### PR TITLE
fix(env): re-sync on hash drift at unchanged commit (auto-heal stale lock)

### DIFF
--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -126,6 +126,19 @@ func SyncEnv(cfg EnvConfig, projectRoot, cacheRoot string, lockEntry *lock.EnvEn
 			if err := ValidatePathUnderRoot(projectRoot, dest); err != nil {
 				return nil, fmt.Errorf("lock entry has invalid dest %q: %w", f.Dest, err)
 			}
+			// A legacy/partial lock entry with no recorded hash can't be compared;
+			// fall back to an existence check (and don't read the file, so a
+			// present-but-unreadable file stays skippable as before).
+			if f.SHA256 == "" {
+				if _, err := os.Stat(dest); err != nil {
+					if os.IsNotExist(err) {
+						inSync = false // missing → re-sync
+						break
+					}
+					return nil, fmt.Errorf("checking synced env file %q: %w", dest, err)
+				}
+				continue
+			}
 			localHash, err := lock.SHA256File(dest)
 			if err != nil {
 				if os.IsNotExist(err) {
@@ -134,9 +147,7 @@ func SyncEnv(cfg EnvConfig, projectRoot, cacheRoot string, lockEntry *lock.EnvEn
 				}
 				return nil, fmt.Errorf("checking synced env file %q: %w", dest, err)
 			}
-			// An empty recorded hash (legacy/partial lock entry) can't be
-			// compared; treat presence as sufficient so we don't re-sync needlessly.
-			if f.SHA256 != "" && localHash != f.SHA256 {
+			if localHash != f.SHA256 {
 				inSync = false // drifted → re-sync (heals a poisoned lock)
 				break
 			}

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -106,25 +106,42 @@ func SyncEnv(cfg EnvConfig, projectRoot, cacheRoot string, lockEntry *lock.EnvEn
 	}
 
 	// Check if up-to-date (skip when forcing a specific commit).
-	// NOTE: This skips when the commit hasn't changed. If only the local config
-	// changed (e.g. select filters), use --force to re-sync.
+	//
+	// Skip only when the commit is unchanged AND every locked file is still
+	// byte-identical to its recorded hash. A missing OR drifted file — local
+	// edits, or a lock written with stale/wrong hashes (e.g. by an older buggy
+	// version) — falls through to a full re-sync, which reconciles via the
+	// per-file strategy + safety gate and re-records the lock. Without the hash
+	// check, a stale lock at an unchanged commit was unhealable: status/verify
+	// reported drift forever while update kept printing "(up to date)".
+	//
+	// This trades a local hash of each synced file (no network) on the
+	// commit-unchanged fast path for self-healing + drift detection — a
+	// deliberate UX-over-compute choice; the network fetch still happens only
+	// when drift is actually found.
 	if cfg.ForceCommit == "" && lockEntry != nil && lockEntry.Commit == commit {
-		// Verify locked files still exist on disk; re-sync if any are missing.
-		allPresent := true
+		inSync := true
 		for _, f := range lockEntry.Files {
 			dest := filepath.Join(projectRoot, f.Dest)
 			if err := ValidatePathUnderRoot(projectRoot, dest); err != nil {
 				return nil, fmt.Errorf("lock entry has invalid dest %q: %w", f.Dest, err)
 			}
-			if _, err := os.Stat(dest); err != nil {
+			localHash, err := lock.SHA256File(dest)
+			if err != nil {
 				if os.IsNotExist(err) {
-					allPresent = false
+					inSync = false // missing → re-sync
 					break
 				}
 				return nil, fmt.Errorf("checking synced env file %q: %w", dest, err)
 			}
+			// An empty recorded hash (legacy/partial lock entry) can't be
+			// compared; treat presence as sufficient so we don't re-sync needlessly.
+			if f.SHA256 != "" && localHash != f.SHA256 {
+				inSync = false // drifted → re-sync (heals a poisoned lock)
+				break
+			}
 		}
-		if allPresent {
+		if inSync {
 			return &SyncResult{
 				Ref:     baseRef,
 				Label:   cfg.Label,

--- a/pkg/env/sync_local_test.go
+++ b/pkg/env/sync_local_test.go
@@ -212,14 +212,28 @@ func TestSyncEnv_LocalSkippedWhenUpToDate(t *testing.T) {
 		},
 	}
 
-	// Lock entry with the same commit → skip path
-	lockEntry := &lock.EnvEntry{Commit: commit}
+	// First sync to populate files on disk and capture their real hashes.
+	first, err := SyncEnv(cfg, project, t.TempDir(), nil)
+	if err != nil {
+		t.Fatalf("initial sync: %v", err)
+	}
+	if len(first.Files) == 0 {
+		t.Fatal("expected synced files")
+	}
+
+	// Lock entry at the same commit WITH the recorded files+hashes, so the skip
+	// path exercises the in-sync hash-match branch (not a vacuous empty list).
+	lockEntry := &lock.EnvEntry{Commit: commit, Files: make([]lock.LockFile, len(first.Files))}
+	for i, f := range first.Files {
+		lockEntry.Files[i] = lock.LockFile{Path: f.Path, Dest: f.Dest, SHA256: f.SHA256}
+	}
+
 	res, err := SyncEnv(cfg, project, t.TempDir(), lockEntry)
 	if err != nil {
 		t.Fatalf("%v", err)
 	}
 	if !res.Skipped {
-		t.Errorf("expected Skipped=true")
+		t.Errorf("expected Skipped=true when commit unchanged and files match their hashes")
 	}
 }
 

--- a/pkg/env/sync_local_test.go
+++ b/pkg/env/sync_local_test.go
@@ -284,6 +284,71 @@ func TestSyncEnv_LocalResyncWhenFileMissing(t *testing.T) {
 	}
 }
 
+// TestSyncEnv_LocalResyncWhenFileDrifted verifies that SyncEnv re-syncs (and
+// thus re-records the lock) when the commit is unchanged but a locked file's
+// on-disk hash no longer matches the lock — e.g. a lock poisoned with wrong
+// hashes by an older buggy version, with the files on disk still correct.
+// Without the hash check this was unhealable: status/verify reported drift
+// forever while update printed "(up to date)".
+func TestSyncEnv_LocalResyncWhenFileDrifted(t *testing.T) {
+	bare, commit := setupLocalBareRepo(t)
+	project := t.TempDir()
+
+	cfg := EnvConfig{
+		Ref:      bare,
+		Strategy: StrategyReplace,
+		Files: map[string]envmatch.GlobConfig{
+			"cfg/*.yaml": {Dest: "configs"},
+		},
+	}
+
+	// First sync — files on disk are byte-identical to upstream.
+	res, err := SyncEnv(cfg, project, t.TempDir(), nil)
+	if err != nil {
+		t.Fatalf("initial sync: %v", err)
+	}
+	if len(res.Files) == 0 {
+		t.Fatal("expected synced files")
+	}
+
+	// Build a lock at the SAME commit but POISON one file's hash. The file on
+	// disk is left untouched (still correct/byte-identical to upstream).
+	const badHash = "0000000000000000000000000000000000000000000000000000000000000000"
+	lockEntry := &lock.EnvEntry{Commit: commit, Files: make([]lock.LockFile, len(res.Files))}
+	var poisonedDest, origHash string
+	for i, f := range res.Files {
+		sha := f.SHA256
+		if i == 0 {
+			poisonedDest, origHash = f.Dest, f.SHA256
+			sha = badHash
+		}
+		lockEntry.Files[i] = lock.LockFile{Path: f.Path, Dest: f.Dest, SHA256: sha}
+	}
+
+	// Re-sync at the same commit — must NOT skip (drift detected via hash).
+	res2, err := SyncEnv(cfg, project, t.TempDir(), lockEntry)
+	if err != nil {
+		t.Fatalf("re-sync: %v", err)
+	}
+	if res2.Skipped {
+		t.Fatal("expected Skipped=false when a locked file's hash drifted from disk")
+	}
+
+	// The healed result must carry the real hash, not the poisoned one.
+	var found bool
+	for _, f := range res2.Files {
+		if f.Dest == poisonedDest {
+			found = true
+			if f.SHA256 != origHash {
+				t.Errorf("expected re-recorded hash %q for %s, got %q", origHash, f.Dest, f.SHA256)
+			}
+		}
+	}
+	if !found {
+		t.Errorf("re-sync result missing the poisoned dest %q", poisonedDest)
+	}
+}
+
 func TestSyncEnv_LocalDryRun(t *testing.T) {
 	bare, _ := setupLocalBareRepo(t)
 	project := t.TempDir()


### PR DESCRIPTION
## Problem

After #170/#172 fixed the path-resolution bug, `b verify` still wasn't clean for a user whose lock had been **poisoned with wrong per-file hashes by an older buggy version**: ~52 files flagged `sha256 mismatch (local changes)` despite being byte-identical to upstream.

Root cause — **no re-heal path**. `SyncEnv`'s up-to-date short-circuit skipped whenever the commit was unchanged and the locked files merely *existed* (`os.Stat`) — it never compared content:

```go
// NOTE: ... use --force to re-sync.   ← but --force was never wired into env sync
if cfg.ForceCommit == "" && lockEntry != nil && lockEntry.Commit == commit {
    // existence check only
    if allPresent { return {Skipped:true, Message:"(up to date)"} }
}
```

So a lock with stale hashes at the current revision was **unhealable**: `status`/`verify` reported drift forever while `b update` printed "(up to date)" and skipped — and the comment's promised `--force` escape hatch didn't exist for envs (`EnvConfig` has no `Force`; `o.Force` only reaches `updateBinaries`).

## Fix

The skip now requires each locked file's on-disk **SHA-256 to match the lock**, not just exist. A missing **or drifted** file falls through to a full re-sync, which:
- **heals a poisoned lock** — for a byte-identical file it's a no-op on disk that re-records the correct hash (verify → clean);
- **surfaces genuine local edits** through the existing per-file **strategy + safety gate** (`replace` prompts, `client` keeps, `merge` 3-ways) instead of silently hiding them.

Legacy lock entries with an empty hash fall back to the existence check (no needless re-sync).

Deliberate **UX-over-compute** trade (per discussion): each synced file is hashed locally (no network) on the commit-unchanged fast path; the upstream fetch still happens only when drift is actually found.

## Behavior change worth noting

`b update` at an unchanged commit now **detects and reconciles** local drift in synced files (previously silently skipped). It's gated by `strategy`/`safety`, so it won't silently clobber — `client` keeps local, `strict`/`prompt` refuse/ask before overwriting. Users who intentionally edit synced files should use `strategy: client`.

## Tests

`TestSyncEnv_LocalResyncWhenFileDrifted` — a present, byte-identical file with a poisoned lock hash at a matching commit no longer skips and re-records the correct hash; **fails without this change**. Existing skip/missing tests still pass.

`go build`, `go vet ./...`, `gofmt`, full `go test ./...` all clean.

> Pushed over HTTPS via the gh token (ssh-agent has no key this session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)